### PR TITLE
Add MatchIn to the possible parameters

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -28,6 +28,10 @@ function Get-ServiceNowChangeRequest {
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -54,6 +58,7 @@ function Get-ServiceNowChangeRequest {
         MatchExact      = $MatchExact
         OrderDirection  = $OrderDirection
         MatchContains   = $MatchContains
+        MatchIn         = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -28,6 +28,10 @@ function Get-ServiceNowConfigurationItem {
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -54,6 +58,7 @@ function Get-ServiceNowConfigurationItem {
         MatchExact      = $MatchExact
         OrderDirection  = $OrderDirection
         MatchContains   = $MatchContains
+        MatchIn         = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -28,6 +28,10 @@ function Get-ServiceNowIncident{
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -50,10 +54,11 @@ function Get-ServiceNowIncident{
 
     # Query Splat
     $newServiceNowQuerySplat = @{
-        OrderBy = $OrderBy
-        OrderDirection = $OrderDirection
-        MatchExact = $MatchExact
-        MatchContains = $MatchContains
+        OrderBy         = $OrderBy
+        OrderDirection  = $OrderDirection
+        MatchExact      = $MatchExact
+        MatchContains   = $MatchContains
+        MatchIn         = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -28,6 +28,10 @@ function Get-ServiceNowRequest {
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -54,6 +58,7 @@ function Get-ServiceNowRequest {
         MatchExact     = $MatchExact
         OrderDirection = $OrderDirection
         MatchContains  = $MatchContains
+        MatchIn        = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -44,6 +44,10 @@ function Get-ServiceNowRequestItem {
         [parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -69,6 +73,7 @@ function Get-ServiceNowRequestItem {
         MatchExact     = $MatchExact
         OrderDirection = $OrderDirection
         MatchContains  = $MatchContains
+        MatchIn        = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -51,6 +51,10 @@ function Get-ServiceNowTableEntry {
         [parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -78,6 +82,7 @@ function Get-ServiceNowTableEntry {
             MatchExact     = $MatchExact
             OrderDirection = $OrderDirection
             MatchContains  = $MatchContains
+            MatchIn        = $MatchIn
             ErrorAction    = 'Stop'
         }
         $Query = New-ServiceNowQuery @newServiceNowQuerySplat

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -27,6 +27,10 @@ function Get-ServiceNowUser{
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
+        
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
 
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
@@ -54,6 +58,7 @@ function Get-ServiceNowUser{
         OrderDirection = $OrderDirection
         MatchExact     = $MatchExact
         MatchContains  = $MatchContains
+        MatchIn        = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -28,6 +28,10 @@ function Get-ServiceNowUserGroup{
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchIn = @{},
+
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
@@ -54,6 +58,7 @@ function Get-ServiceNowUserGroup{
         OrderDirection = $OrderDirection
         MatchExact     = $MatchExact
         MatchContains  = $MatchContains
+        MatchIn        = $MatchIn
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 

--- a/ServiceNow/Public/New-ServiceNowQuery.ps1
+++ b/ServiceNow/Public/New-ServiceNowQuery.ps1
@@ -73,6 +73,14 @@ function New-ServiceNowQuery {
             }
         }
 
+        # Add the values in MatchIn - have to be separated by " , " if in same field ex. Incident=INC0000001,INC0000002 and so on
+        If ($MatchIn) {
+            ForEach ($Field in $MatchIn.keys) {
+                $InString = "^{0}IN{1}" -f $Field.ToString().ToLower(), ($MatchIn.$Field)
+                [void]$Query.Append($InString)
+            }
+        }
+
         # Output StringBuilder to string
         $Query.ToString()
     }

--- a/ServiceNow/Public/New-ServiceNowQuery.ps1
+++ b/ServiceNow/Public/New-ServiceNowQuery.ps1
@@ -40,7 +40,11 @@ function New-ServiceNowQuery {
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
         [parameter(mandatory=$false)]
-        [hashtable]$MatchContains
+        [hashtable]$MatchContains,
+    
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [parameter(mandatory=$false)]
+        [hashtable]$MatchIn
     )
 
     Try {


### PR DESCRIPTION
I needed a function at work to be able to search for multiple incidents within one query - this can be managed through iterating each incident through ForEach but this causes unnecessary queries to be sent - for each incident that would be a separate one instead of one.

This simply adds the possibility of using the IN operator for ServiceNow queries

![GIF 4-25-2020 17-12-01](https://user-images.githubusercontent.com/62133917/80283514-63b51c80-8718-11ea-9f76-099525c952a8.gif)

