### PR TITLE
v2.0 - New session, different api versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0
+- Although still in the module for backward compatibility, `Set-ServiceNowAuth` is being replaced with `New-ServiceNowSession`.  With this comes OAuth support, removal of global variables, and much more folks have asked for.  The ability to provide credentials directly to functions has been retained for this release, but will be deprecated in a future release in favor of using `New-ServiceNowSession`.
+- Support for different api versions.  `Set-ServiceNowAuth` will continue to use v1 of the api, but `New-ServiceNowSession` defaults to the latest.  Check out the `-ApiVersion` parameter of `New-ServiceNowSession`.
+- `Remove-ServiceNowAuth` has been retained for this release, but as global variables have been removed, there is no longer a need for it; it will always return `$true`.  It will be removed in a future release.
+- `-PassThru` added to remaining `Update-` and `New-` functions.  Depending on your code, this may be a ***breaking change*** if you expected the result to be returned.
+- Pipeline support added to many functions
+- Standardizing on coding between all functions
+
 ## v1.8.1
 - Update links to reference the new GitHub organization this project will be moved to.  Module functionality unchanged.
 

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,16 @@ This PowerShell module provides a series of cmdlets for interacting with the [Se
 
 **IMPORTANT:** Neither this module nor its creator are in any way affiliated with ServiceNow.
 
+## Version 2
+
+Building on the great work the community has done thus far, a lot of new updates with this release.
+- Although still in the module for backward compatibility, `Set-ServiceNowAuth` is being replaced with `New-ServiceNowSession`.  With this comes OAuth support, removal of global variables, and much more folks have asked for.  The ability to provide credentials directly to functions has been retained for this release, but will be deprecated in a future release in favor of using `New-ServiceNowSession`.
+- Support for different api versions.  `Set-ServiceNowAuth` will continue to use v1 of the api, but `New-ServiceNowSession` defaults to the latest.  Check out the `-ApiVersion` parameter of `New-ServiceNowSession`.
+- `Remove-ServiceNowAuth` has been retained for this release, but as global variables have been removed, there is no longer a need for it; it will always return `$true`.  It will be removed in a future release.
+- `-PassThru` added to remaining `Update-` and `New-` functions.  Depending on your code, this may be a ***breaking change*** if you expected the result to be returned.
+- Pipeline support added to many functions
+- Standardizing on coding between all functions
+
 ## Version 1
 
 The module has been renamed from PSServiceNow to ServiceNow for version 1.  This change moves us away from the reserved "PS" prefix.  Since the name change is a major change for the user base and the project was never incremented to v1 we've taken the opportunity to label it such.
@@ -108,12 +118,11 @@ The `Connection` parameter accepts a hashtable object that requires a username, 
 * Get-ServiceNowUserGroup
 * New-ServiceNowChangeRequest
 * New-ServiceNowIncident
+* New-ServiceNowSession
 * New-ServiceNowQuery
 * New-ServiceNowTableEntry
 * Remove-ServiceNowAttachment
-* Remove-ServiceNowAuth
 * Remove-ServiceNowTableEntry
-* Set-ServiceNowAuth
 * Test-ServiceNowAuthIsSet
 * Update-ServiceNowChangeRequest
 * Update-ServiceNowIncident

--- a/ServiceNow/Private/Get-ServiceNowAuth.ps1
+++ b/ServiceNow/Private/Get-ServiceNowAuth.ps1
@@ -1,0 +1,53 @@
+function Get-ServiceNowAuth {
+    <#
+    .SYNOPSIS
+    .DESCRIPTION
+    .INPUTS
+        None
+    .OUTPUTS
+        Hashtable
+#>
+
+    [OutputType([Hashtable])]
+    [CmdletBinding()]
+    Param (
+        [Parameter()]
+        [PSCredential] $Credential,
+
+        [Parameter()]
+        [string] $ServiceNowURL,
+
+        [Parameter()]
+        [hashtable] $Connection,
+
+        [Parameter()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+    )
+
+    $hashOut = @{}
+
+    # Get credential and ServiceNow REST URL
+    if ( $ServiceNowSession.Count -gt 0 ) {
+        $hashOut.Uri = $ServiceNowSession.BaseUri
+        if ( $ServiceNowSession.AccessToken ) {
+            $hashOut.Headers = @{
+                'Authorization' = 'Bearer {0}' -f $ServiceNowSession.AccessToken
+            }
+        } else {
+            $hashOut.Credential = $ServiceNowSession.Credential
+        }
+    } elseif ( $Credential -and $ServiceNowURL ) {
+        Write-Warning -Message 'This authentication path, providing URL and credential directly, will be deprecated in a future release.  Please use New-ServiceNowSession.'
+        $hashOut.Uri = 'https://{0}/api/now/v1' -f $ServiceNowURL
+        $hashOut.Credential = $Credential
+    } elseif ( $Connection ) {
+        $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
+        $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
+        $hashOut.Credential = $Credential
+        $hashOut.Uri = 'https://{0}/api/now/v1' -f $Connection.ServiceNowUri
+    } else {
+        throw "Exception:  You must do one of the following to authenticate: `n 1. Call the New-ServiceNowSession cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+    }
+
+    $hashOut
+}

--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -81,36 +81,6 @@ function Invoke-ServiceNowRestMethod {
     $params.Method = $Method
     $params.ContentType = 'application/json'
 
-    # $params = @{
-    #     Method      = $Method
-    #     ContentType = 'application/json'
-    # }
-
-    # # Get credential and ServiceNow REST URL
-    # if ( $ServiceNowSession.Count -gt 0 ) {
-    #     $uri = $ServiceNowSession.BaseUri
-    #     if ( $ServiceNowSession.AccessToken ) {
-    #         $params.Headers = @{
-    #             'Authorization' = 'Bearer {0}' -f $ServiceNowSession.AccessToken
-    #         }
-    #     }
-    # } elseif ( $Credential -and $ServiceNowURL ) {
-    #     Write-Warning -Message 'This authentication path, providing URL and credential directly, will be deprecated in a future release.  Please use New-ServiceNowSession.'
-    #     $uri = 'https://{0}/api/now/v1' -f $ServiceNowURL
-    #     $params.Credential = $Credential
-    # } elseif ( $Connection ) {
-    #     $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-    #     $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-    #     $params.Credential = $Credential
-    #     $uri = 'https://{0}/api/now/v1' -f $Connection.ServiceNowUri
-    # } else {
-    #     throw "Exception:  You must do one of the following to authenticate: `n 1. Call the New-ServiceNowSession cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-    # }
-
-    # if ( $Header ) {
-    #     $params.Headers += $Header
-    # }
-
     if ( $Table ) {
         $params.Uri += "/table/$Table"
         if ( $SysId ) {
@@ -183,7 +153,7 @@ function Invoke-ServiceNowRestMethod {
         $params.Body = $Body
     }
 
-    Write-Verbose ($params | Format-List | Out-String)
+    Write-Verbose ($params | ConvertTo-Json)
 
     $response = Invoke-RestMethod @params
 

--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -1,0 +1,209 @@
+function Invoke-ServiceNowRestMethod {
+    <#
+    .SYNOPSIS
+        Retrieves records for the specified table
+    .DESCRIPTION
+        The Get-ServiceNowTable function retrieves records for the specified table
+    .INPUTS
+        None
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+    .LINK
+        Service-Now Kingston REST Table API: https://docs.servicenow.com/bundle/kingston-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html
+        Service-Now Table API FAQ: https://hi.service-now.com/kb_view.do?sysparm_article=KB0534905
+#>
+
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(SupportsPaging)]
+    Param (
+        [parameter()]
+        [ValidateSet('Get', 'Post', 'Patch', 'Delete')]
+        [string] $Method = 'Get',
+
+        # Name of the table we're querying (e.g. incidents)
+        [parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Table,
+
+        [parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string] $SysId,
+
+        [parameter()]
+        [hashtable] $Values,
+
+        # sysparm_query param in the format of a ServiceNow encoded query string (see http://wiki.servicenow.com/index.php?title=Encoded_Query_Strings)
+        [Parameter()]
+        [string]$Query,
+
+        # Maximum number of records to return
+        [Parameter()]
+        [int]$Limit,
+
+        # Fields to return
+        [Parameter()]
+        [Alias('Fields')]
+        [string[]]$Properties,
+
+        # Whether or not to show human readable display values instead of machine values
+        [Parameter()]
+        [ValidateSet('true', 'false', 'all')]
+        [string]$DisplayValues = 'true',
+
+        [Parameter()]
+        [PSCredential]$Credential,
+
+        [Parameter()]
+        [string] $ServiceNowURL,
+
+        [Parameter()]
+        [hashtable]$Connection,
+
+        [Parameter()]
+        [hashtable] $ServiceNowSession
+    )
+
+    $params = @{
+        Method      = $Method
+        ContentType = 'application/json'
+    }
+
+    # Get credential and ServiceNow REST URL
+    if ( $ServiceNowSession ) {
+        $uri = $ServiceNowSession.BaseUri
+        if ( $ServiceNowSession.AccessToken ) {
+            $params.Headers = @{
+                'Authorization' = 'Bearer {0}' -f $ServiceNowSession.AccessToken
+            }
+        }
+    } elseif ( $Credential -and $ServiceNowURL ) {
+        Write-Warning -Message 'This authentication path, providing URL and credential directly, will be deprecated in a future release.  Please use New-ServiceNowSession.'
+        $uri = 'https://{0}/api/now/v1' -f $ServiceNowURL
+        $params.Credential = $Credential
+    } elseif ( $Connection ) {
+        $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
+        $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
+        $params.Credential = $Credential
+        $uri = 'https://{0}/api/now/v1' -f $Connection.ServiceNowUri
+    } else {
+        throw "Exception:  You must do one of the following to authenticate: `n 1. Call the New-ServiceNowSession cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+    }
+
+    $uri += "/table/$Table"
+    if ( $SysId ) {
+        $uri += "/$SysId"
+    }
+    $params.Uri = $uri
+
+    if ( $Method -eq 'Get') {
+        $Body = @{
+            'sysparm_display_value' = $DisplayValues
+        }
+
+        # Handle paging parameters
+        # If -Limit was provided, write a warning message, but prioritize it over -First.
+        # The value of -First defaults to [uint64]::MaxValue if not specified.
+        # If no paging information was provided, default to the legacy behavior, which was to return 10 records.
+
+        if ($PSBoundParameters.ContainsKey('Limit')) {
+            Write-Warning "The -Limit parameter is deprecated, and may be removed in a future release. Use the -First parameter instead."
+            $Body['sysparm_limit'] = $Limit
+        } elseif ($PSCmdlet.PagingParameters.First -ne [uint64]::MaxValue) {
+            $Body['sysparm_limit'] = $PSCmdlet.PagingParameters.First
+        } else {
+            $Body['sysparm_limit'] = 10
+        }
+
+        if ($PSCmdlet.PagingParameters.Skip) {
+            $Body['sysparm_offset'] = $PSCmdlet.PagingParameters.Skip
+        }
+
+        if ($PSCmdlet.PagingParameters.IncludeTotalCount) {
+            # Accuracy is a double between 0.0 and 1.0 representing an estimated percentage accuracy.
+            # 0.0 means we have no idea and 1.0 means the number is exact.
+
+            # ServiceNow does return this information in the X-Total-Count response header,
+            # but we're currently using Invoke-RestMethod to perform the API call, and Invoke-RestMethod
+            # does not provide the response headers, so we can't capture this info.
+
+            # To properly support this parameter, we'd need to fall back on Invoke-WebRequest, read the
+            # X-Total-Count header of the response, and update this parameter after performing the API
+            # call.
+
+            # Reference:
+            # https://developer.servicenow.com/app.do#!/rest_api_doc?v=jakarta&id=r_TableAPI-GET
+
+            [double] $accuracy = 0.0
+            $PSCmdlet.PagingParameters.NewTotalCount($PSCmdlet.PagingParameters.First, $accuracy)
+        }
+
+        # Populate the query
+        if ($Query) {
+            $Body.sysparm_query = $Query
+        }
+
+        if ($Properties) {
+            $Body.sysparm_fields = ($Properties -join ',').ToLower()
+        }
+    }
+
+    if ( $Values ) {
+        $Body = $Values | ConvertTo-Json
+
+        #Convert to UTF8 array to support special chars such as the danish "ï¿½","ï¿½","ï¿½"
+        $body = [System.Text.Encoding]::UTf8.GetBytes($Body)
+    }
+
+    if ( $Body ) {
+        $params.Body = $Body
+    }
+
+    Write-Verbose ($params | Format-List | Out-String)
+
+    $response = Invoke-RestMethod @params
+
+    switch ($Method) {
+        'Get' {
+            $result = $response | Select-Object -ExpandProperty result
+            $ConvertToDateField = @('closed_at', 'expected_start', 'follow_up', 'opened_at', 'sys_created_on', 'sys_updated_on', 'work_end', 'work_start')
+            ForEach ($SNResult in $Result) {
+                ForEach ($Property in $ConvertToDateField) {
+                    If (-not [string]::IsNullOrEmpty($SNResult.$Property)) {
+                        Try {
+                            # Extract the default Date/Time formatting from the local computer's "Culture" settings, and then create the format to use when parsing the date/time from Service-Now
+                            $CultureDateTimeFormat = (Get-Culture).DateTimeFormat
+                            $DateFormat = $CultureDateTimeFormat.ShortDatePattern
+                            $TimeFormat = $CultureDateTimeFormat.LongTimePattern
+                            $DateTimeFormat = "$DateFormat $TimeFormat"
+                            $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DateTimeFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo, [System.Globalization.DateTimeStyles]::None)
+                        } Catch {
+                            Try {
+                                # Universal Format
+                                $DateTimeFormat = 'yyyy-MM-dd HH:mm:ss'
+                                $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DateTimeFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo, [System.Globalization.DateTimeStyles]::None)
+                            } Catch {
+                                # If the local culture and universal formats both fail keep the property as a string (Do nothing)
+                                $null = 'Silencing a PSSA alert with this line'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        { $_ -in 'Post', 'Patch' } {
+            $result = $response | Select-Object -ExpandProperty result
+        }
+
+        'Delete' {
+            # nothing to do
+        }
+
+        Default {
+            # we should never get here given the list of methods is set
+        }
+    }
+
+    $result
+    # Invoke-RestMethod -Uri $Uri -Credential $Credential -Body $Body -ContentType "application/json" | Select-Object -ExpandProperty Result
+}

--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -69,7 +69,7 @@ function Invoke-ServiceNowRestMethod {
     }
 
     # Get credential and ServiceNow REST URL
-    if ( $ServiceNowSession ) {
+    if ( $ServiceNowSession.Count -gt 0 ) {
         $uri = $ServiceNowSession.BaseUri
         if ( $ServiceNowSession.AccessToken ) {
             $params.Headers = @{

--- a/ServiceNow/Private/Test-ServiceNowURL.ps1
+++ b/ServiceNow/Private/Test-ServiceNowURL.ps1
@@ -9,31 +9,27 @@ Function Test-ServiceNowURL {
     .EXAMPLE
     Test-ServiceNowURL -Url tenant.domain.com
 
-    This example can have text
-
     .OUTPUTS
     System.Boolean
-
     #>
 
     [OutputType([System.Boolean])]
     [CmdletBinding()]
     param (
         # Pipeline variable
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
-        [string]$Url
+        [string] $Url
     )
 
-	begin {}
-	process	{
+    begin {}
+    process	{
         Write-Verbose "Testing url:  $Url"
-		if ($Url -match '^\w+\..*\.\w+') {
+        if ($Url -match '^\w+\..*\.\w+') {
             $true
-        }
-        else {
+        } else {
             Throw "The expected URL format is tenant.domain.com"
         }
     }
-	end {}
+    end {}
 }

--- a/ServiceNow/Public/Add-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Add-ServiceNowAttachment.ps1
@@ -37,46 +37,46 @@ Function Add-ServiceNowAttachment {
 
     #>
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText','')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars','')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars', '')]
 
     [OutputType([PSCustomObject[]])]
-    [CmdletBinding(DefaultParameterSetName,SupportsShouldProcess=$true)]
+    [CmdletBinding(DefaultParameterSetName, SupportsShouldProcess = $true)]
     Param(
         # Object number
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [string]$Number,
 
         # Table containing the entry
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory)]
         [string]$Table,
 
         # Filter results by file name
-        [parameter(Mandatory=$true)]
-        [ValidateScript({
-            Test-Path $_
-        })]
+        [parameter(Mandatory)]
+        [ValidateScript( {
+                Test-Path $_
+            })]
         [string[]]$File,
 
         # Content (MIME) type - if not automatically determined
-        [Parameter(Mandatory=$false)]
+        [Parameter()]
         [string]$ContentType,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
         # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Hashtable]$Connection,
 
@@ -85,89 +85,136 @@ Function Add-ServiceNowAttachment {
         [switch]$PassThru
     )
 
-	begin {}
-	process	{
-        Try {
-            # Use the number and table to determine the sys_id
-            $getServiceNowTableEntry = @{
-                Table         = $Table
-                MatchExact    = @{number = $number}
-                ErrorAction   = 'Stop'
+    begin {}
+    process	{
+
+        $getSysIdParams = @{
+            Table             = $Table
+            Query             = (New-ServiceNowQuery -MatchExact @{'number' = $number })
+            Properties        = 'sys_id'
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        # Use the number and table to determine the sys_id
+        $sysId = Invoke-ServiceNowRestMethod @getSysIdParams | Select-Object -ExpandProperty sys_id
+
+        $getAuth = @{
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowUrl
+            Connection        = $Connection
+            ServiceNowSession = $ServiceNowSession
+        }
+        $auth = Get-ServiceNowAuth @getAuth
+
+        ForEach ($Object in $File) {
+            $FileData = Get-ChildItem $Object -ErrorAction Stop
+            If (-not $ContentType) {
+                Add-Type -AssemblyName 'System.Web'
+                $ContentType = [System.Web.MimeMapping]::GetMimeMapping($FileData.FullName)
             }
 
-            # Update the Table Splat if an applicable parameter set name is in use
-            Switch ($PSCmdlet.ParameterSetName) {
-                'SpecifyConnectionFields' {
-                    $getServiceNowTableEntry.Add('Credential', $Credential)
-                    $getServiceNowTableEntry.Add('ServiceNowURL', $ServiceNowURL)
-                    break
-                }
-                'UseConnectionObject' {
-                    $getServiceNowTableEntry.Add('Connection', $Connection)
-                    break
-                }
-                Default {
-                    If (-not (Test-ServiceNowAuthIsSet)) {
-                        Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-                    }
-                }
+            # POST: https://instance.service-now.com/api/now/attachment/file?table_name=incident&table_sys_id=d71f7935c0a8016700802b64c67c11c6&file_name=Issue_screenshot
+            # $Uri = "{0}/file?table_name={1}&table_sys_id={2}&file_name={3}" -f $ApiUrl, $Table, $TableSysID, $FileData.Name
+            $invokeRestMethodSplat = $auth
+            $invokeRestMethodSplat.Uri += '/file?table_name={0}&table_sys_id={1}&file_name={2}' -f $Table, $sysId, $FileData.Name
+            $invokeRestMethodSplat.Headers += @{'Content-Type' = $ContentType }
+            $invokeRestMethodSplat += @{
+                Method = 'POST'
+                InFile = $FileData.FullName
             }
 
-            $TableSysID = Get-ServiceNowTableEntry @getServiceNowTableEntry | Select-Object -Expand sys_id
+            If ($PSCmdlet.ShouldProcess("$Table $Number", 'Add attachment')) {
+                $invokeRestMethodSplat|ConvertTo-Json
+                $response = Invoke-RestMethod @invokeRestMethodSplat
 
-            # Process credential steps based on parameter set name
-            Switch ($PSCmdlet.ParameterSetName) {
-                'SpecifyConnectionFields' {
-                    $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
-                    break
-                }
-                'UseConnectionObject' {
-                    $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-                    $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-                    $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
-                    break
-                }
-                Default {
-                    If ((Test-ServiceNowAuthIsSet)) {
-                        $Credential = $Global:ServiceNowCredentials
-                        $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
-                    }
-                    Else {
-                        Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-                    }
-                }
-            }
-
-            ForEach ($Object in $File) {
-                $FileData = Get-ChildItem $Object -ErrorAction Stop
-                If (-not $ContentType) {
-                    Add-Type -AssemblyName 'System.Web'
-                    $ContentType = [System.Web.MimeMapping]::GetMimeMapping($FileData.FullName)
-                }
-
-                # POST: https://instance.service-now.com/api/now/attachment/file?table_name=incident&table_sys_id=d71f7935c0a8016700802b64c67c11c6&file_name=Issue_screenshot
-                $Uri = "{0}/file?table_name={1}&table_sys_id={2}&file_name={3}" -f $ApiUrl,$Table,$TableSysID,$FileData.Name
-
-                $invokeRestMethodSplat = @{
-                    Uri        = $Uri
-                    Headers    = @{'Content-Type' = $ContentType}
-                    Method     = 'POST'
-                    InFile     = $FileData.FullName
-                    Credential = $Credential
-                }
-
-                If ($PSCmdlet.ShouldProcess($Uri,$MyInvocation.MyCommand)) {
-                    $Result = (Invoke-RestMethod @invokeRestMethodSplat).Result
-
-                    If ($PassThru) {
-                        $Result | Update-ServiceNowDateTimeField
-                    }
+                If ($PassThru) {
+                    $response
                 }
             }
         }
-        Catch {
-            Write-Error $PSItem
-        }
+
+        # Try {
+        #     # Use the number and table to determine the sys_id
+        #     $getServiceNowTableEntry = @{
+        #         Table       = $Table
+        #         MatchExact  = @{number = $number }
+        #         ErrorAction = 'Stop'
+        #     }
+
+        #     # Update the Table Splat if an applicable parameter set name is in use
+        #     Switch ($PSCmdlet.ParameterSetName) {
+        #         'SpecifyConnectionFields' {
+        #             $getServiceNowTableEntry.Add('Credential', $Credential)
+        #             $getServiceNowTableEntry.Add('ServiceNowURL', $ServiceNowURL)
+        #             break
+        #         }
+        #         'UseConnectionObject' {
+        #             $getServiceNowTableEntry.Add('Connection', $Connection)
+        #             break
+        #         }
+        #         Default {
+        #             If (-not (Test-ServiceNowAuthIsSet)) {
+        #                 Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+        #             }
+        #         }
+        #     }
+
+        #     $TableSysID = Get-ServiceNowTableEntry @getServiceNowTableEntry | Select-Object -Expand sys_id
+
+        #     # Process credential steps based on parameter set name
+        #     Switch ($PSCmdlet.ParameterSetName) {
+        #         'SpecifyConnectionFields' {
+        #             $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
+        #             break
+        #         }
+        #         'UseConnectionObject' {
+        #             $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
+        #             $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
+        #             $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
+        #             break
+        #         }
+        #         Default {
+        #             If ((Test-ServiceNowAuthIsSet)) {
+        #                 $Credential = $Global:ServiceNowCredentials
+        #                 $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
+        #             } Else {
+        #                 Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+        #             }
+        #         }
+        #     }
+
+        #     ForEach ($Object in $File) {
+        #         $FileData = Get-ChildItem $Object -ErrorAction Stop
+        #         If (-not $ContentType) {
+        #             Add-Type -AssemblyName 'System.Web'
+        #             $ContentType = [System.Web.MimeMapping]::GetMimeMapping($FileData.FullName)
+        #         }
+
+        #         # POST: https://instance.service-now.com/api/now/attachment/file?table_name=incident&table_sys_id=d71f7935c0a8016700802b64c67c11c6&file_name=Issue_screenshot
+        #         $Uri = "{0}/file?table_name={1}&table_sys_id={2}&file_name={3}" -f $ApiUrl, $Table, $TableSysID, $FileData.Name
+
+        #         $invokeRestMethodSplat = @{
+        #             Uri        = $Uri
+        #             Headers    = @{'Content-Type' = $ContentType }
+        #             Method     = 'POST'
+        #             InFile     = $FileData.FullName
+        #             Credential = $Credential
+        #         }
+
+        #         If ($PSCmdlet.ShouldProcess($Uri, $MyInvocation.MyCommand)) {
+        #             $Result = (Invoke-RestMethod @invokeRestMethodSplat).Result
+
+        #             If ($PassThru) {
+        #                 $Result | Update-ServiceNowDateTimeField
+        #             }
+        #         }
+        #     }
+        # } Catch {
+        #     Write-Error $PSItem
+        # }
     }
-	end {}
+    end {}
 }

--- a/ServiceNow/Public/Add-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Add-ServiceNowAttachment.ps1
@@ -121,7 +121,7 @@ Function Add-ServiceNowAttachment {
             # POST: https://instance.service-now.com/api/now/attachment/file?table_name=incident&table_sys_id=d71f7935c0a8016700802b64c67c11c6&file_name=Issue_screenshot
             # $Uri = "{0}/file?table_name={1}&table_sys_id={2}&file_name={3}" -f $ApiUrl, $Table, $TableSysID, $FileData.Name
             $invokeRestMethodSplat = $auth
-            $invokeRestMethodSplat.Uri += '/file?table_name={0}&table_sys_id={1}&file_name={2}' -f $Table, $sysId, $FileData.Name
+            $invokeRestMethodSplat.Uri += '/attachment/file?table_name={0}&table_sys_id={1}&file_name={2}' -f $Table, $sysId, $FileData.Name
             $invokeRestMethodSplat.Headers += @{'Content-Type' = $ContentType }
             $invokeRestMethodSplat += @{
                 Method = 'POST'
@@ -129,11 +129,11 @@ Function Add-ServiceNowAttachment {
             }
 
             If ($PSCmdlet.ShouldProcess("$Table $Number", 'Add attachment')) {
-                $invokeRestMethodSplat | ConvertTo-Json
+                Write-Verbose ($invokeRestMethodSplat | ConvertTo-Json)
                 $response = Invoke-RestMethod @invokeRestMethodSplat
 
                 If ($PassThru) {
-                    $response
+                    $response.result
                 }
             }
         }

--- a/ServiceNow/Public/Get-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Get-ServiceNowAttachment.ps1
@@ -45,115 +45,135 @@ Function Get-ServiceNowAttachment {
 
     #>
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText','')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars','')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars', '')]
 
-    [CmdletBinding(DefaultParameterSetName,SupportsShouldProcess=$true)]
+    [CmdletBinding(DefaultParameterSetName, SupportsShouldProcess = $true)]
     Param(
         # Object number
-        [Parameter(
-            Mandatory=$true,
-            ValueFromPipelineByPropertyName = $true
-        )]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('sys_id')]
-        [string]$SysID,
+        [string]$SysId,
 
-        [Parameter(
-            Mandatory=$true,
-            ValueFromPipelineByPropertyName = $true
-        )]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('file_name')]
         [string]$FileName,
 
         # Out path to download files
-        [parameter(Mandatory=$false)]
-        [ValidateScript({
-            Test-Path $_
-        })]
+        [parameter()]
+        [ValidateScript( {
+                Test-Path $_
+            })]
         [string]$Destination = $PWD.Path,
 
         # Options impacting downloads
-        [parameter(Mandatory=$false)]
+        [parameter()]
         [switch]$AllowOverwrite,
 
         # Options impacting downloads
-        [parameter(Mandatory=$false)]
+        [parameter()]
         [switch]$AppendNameWithSysID,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
         # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection
+        [Hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-	begin {}
-	process	{
-        Try {
-            # Process credential steps based on parameter set name
-            Switch ($PSCmdlet.ParameterSetName) {
-                'SpecifyConnectionFields' {
-                    $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
-                    break
-                }
-                'UseConnectionObject' {
-                    $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-                    $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-                    $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
-                    break
-                }
-                Default {
-                    If ((Test-ServiceNowAuthIsSet)) {
-                        $Credential = $Global:ServiceNowCredentials
-                        $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
-                    }
-                    Else {
-                        Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-                    }
+    begin {}
+    process	{
+        # Try {
+        $params = @{}
+
+        if ( $ServiceNowSession ) {
+            $params.uri = $ServiceNowSession.BaseUri
+            if ( $ServiceNowSession.AccessToken ) {
+                $params.Headers = @{
+                    'Authorization' = 'Bearer {0}' -f $ServiceNowSession.AccessToken
                 }
             }
-
-            # URI format:  https://tenant.service-now.com/api/now/v1/attachment/{sys_id}/file
-            $Uri = $ApiUrl + '/' + $SysID + '/file'
-
-            If ($True -eq $PSBoundParameters.ContainsKey('AppendNameWithSysID')) {
-                $FileName = "{0}_{1}{2}" -f [io.path]::GetFileNameWithoutExtension($FileName),
-                $SysID,[io.path]::GetExtension($FileName)
-            }
-            $OutFile = $Null
-            $OutFile = Join-Path $Destination $FileName
-
-            If ((Test-Path $OutFile) -and -not $PSBoundParameters.ContainsKey('AllowOverwrite')) {
-                $ThrowMessage = "The file [{0}] already exists.  Please choose a different name, use the -AppendNameWithSysID switch parameter, or use the -AllowOverwrite switch parameter to overwrite the file." -f $OutFile
-                Throw $ThrowMessage
-            }
-
-            $invokeRestMethodSplat = @{
-                Uri         = $Uri
-                Credential  = $Credential
-                OutFile     = $OutFile
-            }
-
-            If ($PSCmdlet.ShouldProcess($Uri,$MyInvocation.MyCommand)) {
-                Invoke-RestMethod @invokeRestMethodSplat
-            }
+        } elseif ( $Credential -and $ServiceNowURL ) {
+            Write-Warning -Message 'This authentication path, providing URL and credential directly, will be deprecated in a future release.  Please use New-ServiceNowSession.'
+            $params.$uri = 'https://{0}/api/now/v1' -f $ServiceNowURL
+            $params.Credential = $Credential
+        } elseif ( $Connection ) {
+            $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
+            $params.Credential = $Credential
+            $params.$uri = 'https://{0}/api/now/v1' -f $Connection.ServiceNowUri
+        } else {
+            throw "Exception:  You must do one of the following to authenticate: `n 1. Call the New-ServiceNowSession cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
         }
-        Catch {
-            Write-Error $PSItem
+
+        # Process credential steps based on parameter set name
+        # Switch ($PSCmdlet.ParameterSetName) {
+        #     'SpecifyConnectionFields' {
+        #         $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
+        #         break
+        #     }
+        #     'UseConnectionObject' {
+        #         $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
+        #         $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
+        #         $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
+        #         break
+        #     }
+        #     Default {
+        #         If ((Test-ServiceNowAuthIsSet)) {
+        #             $Credential = $Global:ServiceNowCredentials
+        #             $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
+        #         } Else {
+        #             Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+        #         }
+        #     }
+        # }
+
+        # URI format:  https://tenant.service-now.com/api/now/v1/attachment/{sys_id}/file
+        $params.uri += '/attachment/' + $SysID + '/file'
+
+        If ($AppendNameWithSysID.IsPresent) {
+            $FileName = "{0}_{1}{2}" -f [io.path]::GetFileNameWithoutExtension($FileName),
+            $SysID, [io.path]::GetExtension($FileName)
         }
+        $OutFile = $Null
+        $OutFile = Join-Path $Destination $FileName
+
+        If ((Test-Path $OutFile) -and -not $PSBoundParameters.ContainsKey('AllowOverwrite')) {
+            $ThrowMessage = "The file [{0}] already exists.  Please choose a different name, use the -AppendNameWithSysID switch parameter, or use the -AllowOverwrite switch parameter to overwrite the file." -f $OutFile
+            Throw $ThrowMessage
+        }
+
+        $params.OutFile = $OutFile
+        # $invokeRestMethodSplat = @{
+        #     Uri        = $Uri
+        #     Credential = $Credential
+        #     OutFile    = $OutFile
+        # }
+
+        If ($PSCmdlet.ShouldProcess("SysId $SysId", "Save attachment to file $OutFile")) {
+            Invoke-RestMethod @params
+        }
+        # }
+        # Catch {
+        #     Write-Error $PSItem
+        # }
 
     }
-	end {}
+    end {}
 }

--- a/ServiceNow/Public/Get-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Get-ServiceNowAttachment.ps1
@@ -99,7 +99,6 @@ Function Get-ServiceNowAttachment {
 
     begin {}
     process	{
-        # Try {
         $params = @{}
 
         if ( $ServiceNowSession ) {
@@ -122,29 +121,8 @@ Function Get-ServiceNowAttachment {
             throw "Exception:  You must do one of the following to authenticate: `n 1. Call the New-ServiceNowSession cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
         }
 
-        # Process credential steps based on parameter set name
-        # Switch ($PSCmdlet.ParameterSetName) {
-        #     'SpecifyConnectionFields' {
-        #         $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
-        #         break
-        #     }
-        #     'UseConnectionObject' {
-        #         $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-        #         $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-        #         $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
-        #         break
-        #     }
-        #     Default {
-        #         If ((Test-ServiceNowAuthIsSet)) {
-        #             $Credential = $Global:ServiceNowCredentials
-        #             $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
-        #         } Else {
-        #             Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-        #         }
-        #     }
-        # }
 
-        # URI format:  https://tenant.service-now.com/api/now/v1/attachment/{sys_id}/file
+        # URI format:  https://tenant.service-now.com/api/now/attachment/{sys_id}/file
         $params.uri += '/attachment/' + $SysID + '/file'
 
         If ($AppendNameWithSysID.IsPresent) {
@@ -154,25 +132,16 @@ Function Get-ServiceNowAttachment {
         $OutFile = $Null
         $OutFile = Join-Path $Destination $FileName
 
-        If ((Test-Path $OutFile) -and -not $PSBoundParameters.ContainsKey('AllowOverwrite')) {
+        If ((Test-Path $OutFile) -and -not $AllowOverwrite.IsPresent) {
             $ThrowMessage = "The file [{0}] already exists.  Please choose a different name, use the -AppendNameWithSysID switch parameter, or use the -AllowOverwrite switch parameter to overwrite the file." -f $OutFile
             Throw $ThrowMessage
         }
 
         $params.OutFile = $OutFile
-        # $invokeRestMethodSplat = @{
-        #     Uri        = $Uri
-        #     Credential = $Credential
-        #     OutFile    = $OutFile
-        # }
 
         If ($PSCmdlet.ShouldProcess("SysId $SysId", "Save attachment to file $OutFile")) {
             Invoke-RestMethod @params
         }
-        # }
-        # Catch {
-        #     Write-Error $PSItem
-        # }
 
     }
     end {}

--- a/ServiceNow/Public/Get-ServiceNowAttachmentDetail.ps1
+++ b/ServiceNow/Public/Get-ServiceNowAttachmentDetail.ps1
@@ -32,121 +32,79 @@ Function Get-ServiceNowAttachmentDetail {
 
     #>
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText','')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars','')]
-
     [OutputType([System.Management.Automation.PSCustomObject[]])]
     [CmdletBinding(DefaultParameterSetName)]
     Param(
-        # Object number
-        [Parameter(Mandatory=$true)]
-        [string]$Number,
-
         # Table containing the entry
-        [Parameter(Mandatory=$true)]
-        [string]$Table,
+        [Parameter(Mandatory)]
+        [string] $Table,
+
+        # Object number
+        [Parameter(Mandatory)]
+        [string] $Number,
 
         # Filter results by file name
-        [parameter(Mandatory=$false)]
-        [string[]]$FileName,
+        [parameter()]
+        [string[]] $FileName,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
         # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
-        [string]$ServiceNowURL,
+        [string] $ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection
+        [Hashtable] $Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-	begin {}
-	process	{
-        Try {
-            # Use the number and table to determine the sys_id
-            $getServiceNowTableEntry = @{
-                Table         = $Table
-                MatchExact    = @{number = $number}
-                ErrorAction   = 'Stop'
-            }
+    begin {}
 
-            # Update the Table Splat if an applicable parameter set name is in use
-            Switch ($PSCmdlet.ParameterSetName) {
-                'SpecifyConnectionFields' {
-                    $getServiceNowTableEntry.Add('Credential', $Credential)
-                    $getServiceNowTableEntry.Add('ServiceNowURL', $ServiceNowURL)
-                    break
-                }
-                'UseConnectionObject' {
-                    $getServiceNowTableEntry.Add('Connection', $Connection)
-                    break
-                }
-                Default {
-                    If (-not (Test-ServiceNowAuthIsSet)) {
-                        Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-                    }
-                }
-            }
+    process	{
 
-            $TableSysID = Get-ServiceNowTableEntry @getServiceNowTableEntry | Select-Object -Expand sys_id
-
-            # Process credential steps based on parameter set name
-            Switch ($PSCmdlet.ParameterSetName) {
-                'SpecifyConnectionFields' {
-                    $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
-                    break
-                }
-                'UseConnectionObject' {
-                    $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-                    $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-                    $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
-                    break
-                }
-                Default {
-                    If ((Test-ServiceNowAuthIsSet)) {
-                        $Credential = $Global:ServiceNowCredentials
-                        $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
-                    }
-                    Else {
-                        Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-                    }
-                }
-            }
-
-            # Populate the query
-            $Body = @{'sysparm_limit' = 500; 'table_name' = $Table; 'table_sys_id' = $TableSysID}
-            $Body.sysparm_query = 'ORDERBYfile_name^ORDERBYDESC'
-
-            # Perform table query and capture results
-            $Uri = $ApiUrl
-
-            $invokeRestMethodSplat = @{
-                Uri         = $Uri
-                Body        = $Body
-                Credential  = $Credential
-                ContentType = 'application/json'
-            }
-            $Result = (Invoke-RestMethod @invokeRestMethodSplat).Result
-
-            # Filter for requested file names
-            If ($FileName) {
-                $Result = $Result | Where-Object {$PSItem.file_name -match ($FileName -join '|')}
-            }
-
-            $Result | Update-ServiceNowDateTimeField
+        $getSysIdParams = @{
+            Table             = $Table
+            Query             = (New-ServiceNowQuery -MatchExact @{'number' = $number })
+            Properties        = 'sys_id'
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
         }
-        Catch {
-            Write-Error $PSItem
+
+        # Use the number and table to determine the sys_id
+        $sysId = Invoke-ServiceNowRestMethod @getSysIdParams | Select-Object -ExpandProperty sys_id
+
+        $getSysIdParams = @{
+            Uri               = '/attachment'
+            Query             = (New-ServiceNowQuery -MatchExact @{
+                    table_name   = $Table
+                    table_sys_id = $sysId
+                })
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
         }
+        $response = Invoke-ServiceNowRestMethod @getSysIdParams
+
+        if ( $FileName ) {
+            $response = $response | Where-Object { $_.file_name -in $FileName }
+        }
+
+        $response | Update-ServiceNowDateTimeField
     }
-	end {}
+    end {}
 }

--- a/ServiceNow/Public/Get-ServiceNowAttachmentDetail.ps1
+++ b/ServiceNow/Public/Get-ServiceNowAttachmentDetail.ps1
@@ -51,7 +51,7 @@ Function Get-ServiceNowAttachmentDetail {
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
-        [PSCredential]$Credential,
+        [PSCredential] $Credential,
 
         # The URL for the ServiceNow instance being used
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
@@ -87,7 +87,7 @@ Function Get-ServiceNowAttachmentDetail {
         # Use the number and table to determine the sys_id
         $sysId = Invoke-ServiceNowRestMethod @getSysIdParams | Select-Object -ExpandProperty sys_id
 
-        $getSysIdParams = @{
+        $params = @{
             Uri               = '/attachment'
             Query             = (New-ServiceNowQuery -MatchExact @{
                     table_name   = $Table
@@ -98,7 +98,7 @@ Function Get-ServiceNowAttachmentDetail {
             ServiceNowUrl     = $ServiceNowURL
             ServiceNowSession = $ServiceNowSession
         }
-        $response = Invoke-ServiceNowRestMethod @getSysIdParams
+        $response = Invoke-ServiceNowRestMethod @params
 
         if ( $FileName ) {
             $response = $response | Where-Object { $_.file_name -in $FileName }
@@ -106,5 +106,6 @@ Function Get-ServiceNowAttachmentDetail {
 
         $response | Update-ServiceNowDateTimeField
     }
+
     end {}
 }

--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -4,48 +4,48 @@ function Get-ServiceNowChangeRequest {
     Param(
         # Machine name of the field to order by
         [Parameter()]
-        [string]$OrderBy = 'opened_at',
+        [string] $OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
         [Parameter()]
         [ValidateSet('Desc', 'Asc')]
-        [string]$OrderDirection = 'Desc',
+        [string] $OrderDirection = 'Desc',
 
         # Maximum number of records to return
         [Parameter()]
-        [int]$Limit,
+        [int] $Limit,
 
         # Fields to return
         [Parameter()]
         [Alias('Fields')]
-        [string[]]$Properties,
+        [string[]] $Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter()]
-        [hashtable]$MatchExact = @{},
+        [hashtable] $MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
         [Parameter()]
-        [hashtable]$MatchContains = @{},
+        [hashtable] $MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
         [Parameter()]
         [ValidateSet('true', 'false', 'all')]
-        [string]$DisplayValues = 'true',
+        [string] $DisplayValues = 'true',
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
-        [PSCredential]$Credential,
+        [PSCredential] $Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateScript( { $_ | Test-ServiceNowURL })]
         [Alias('Url')]
-        [string]$ServiceNowURL,
+        [string] $ServiceNowURL,
 
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection,
+        [hashtable] $Connection,
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]

--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -52,7 +52,7 @@ function Get-ServiceNowChangeRequest {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'change_request'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'change_request'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.ChangeRequest") }

--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowChangeRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -33,61 +33,29 @@ function Get-ServiceNowChangeRequest {
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript( { Test-ServiceNowURL -Url $_ })]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy         = $OrderBy
-        MatchExact      = $MatchExact
-        OrderDirection  = $OrderDirection
-        MatchContains   = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    $result = Get-ServiceNowTable @PSBoundParameters -Table 'change_request'
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'change_request'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
-
-    # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
-
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
-
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-    }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
     If (-not $Properties) {
-        $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.ChangeRequest")}
+        $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.ChangeRequest") }
     }
-    $Result
+    $result
 }

--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -3,33 +3,33 @@ function Get-ServiceNowChangeRequest {
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
@@ -39,7 +39,7 @@ function Get-ServiceNowChangeRequest {
         [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
-        [ValidateScript( { Test-ServiceNowURL -Url $_ })]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
@@ -54,7 +54,7 @@ function Get-ServiceNowChangeRequest {
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'change_request'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.ChangeRequest") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -3,33 +3,33 @@ function Get-ServiceNowConfigurationItem {
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string]$OrderBy = 'name',
 
         # Direction of ordering (Desc/Asc)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
@@ -39,7 +39,7 @@ function Get-ServiceNowConfigurationItem {
         [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [ValidateScript({$_ | Test-ServiceNowURL})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
@@ -54,7 +54,7 @@ function Get-ServiceNowConfigurationItem {
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'cmdb_ci'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.ConfigurationItem") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -48,46 +48,10 @@ function Get-ServiceNowConfigurationItem {
         [hashtable]$Connection
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy         = $OrderBy
-        MatchExact      = $MatchExact
-        OrderDirection  = $OrderDirection
-        MatchContains   = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    $result = Get-ServiceNowTable @PSBoundParameters -Table 'cmdb_ci'
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'cmdb_ci'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
-
-    # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
-
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
-
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-    }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
     If (-not $Properties) {
-        $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.ConfigurationItem")}
+        $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.ConfigurationItem") }
     }
-    $Result
+    $result
 }

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowConfigurationItem {
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -33,19 +33,23 @@ function Get-ServiceNowConfigurationItem {
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateScript({Test-ServiceNowURL -Url $_})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
     $result = Get-ServiceNowTable @PSBoundParameters -Table 'cmdb_ci'

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -52,7 +52,7 @@ function Get-ServiceNowConfigurationItem {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'cmdb_ci'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'cmdb_ci'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.ConfigurationItem") }

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -3,33 +3,33 @@ function Get-ServiceNowIncident {
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
@@ -54,7 +54,7 @@ function Get-ServiceNowIncident {
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'incident'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.Incident") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -52,7 +52,7 @@ function Get-ServiceNowIncident {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'incident'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'incident'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.Incident") }

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -39,7 +39,7 @@ function Get-ServiceNowIncident {
         [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
-        [ValidateScript( { Test-ServiceNowURL -Url $_ })]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [Alias('Url')]
         [string]$ServiceNowURL,
 

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -52,7 +52,7 @@ function Get-ServiceNowRequest {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sc_request'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sc_request'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.Request") }

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -33,61 +33,29 @@ function Get-ServiceNowRequest {
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateScript({Test-ServiceNowURL -Url $_})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy        = $OrderBy
-        MatchExact     = $MatchExact
-        OrderDirection = $OrderDirection
-        MatchContains  = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sc_request'
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'sc_request'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
-
-    # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
-
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
-
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-    }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
     If (-not $Properties) {
-        $Result | ForEach-Object {$_.PSObject.TypeNames.Insert(0, "ServiceNow.Request")}
+        $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.Request") }
     }
-    $Result
+    $result
 }

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -3,33 +3,33 @@ function Get-ServiceNowRequest {
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
@@ -39,7 +39,7 @@ function Get-ServiceNowRequest {
         [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [ValidateScript({$_ | Test-ServiceNowURL})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
@@ -54,7 +54,7 @@ function Get-ServiceNowRequest {
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sc_request'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.Request") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -16,7 +16,7 @@ function Get-ServiceNowRequestItem {
 #>
 
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     param(
         # Machine name of the field to order by
         [parameter(Mandatory = $false)]
@@ -49,60 +49,28 @@ function Get-ServiceNowRequestItem {
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy        = $OrderBy
-        MatchExact     = $MatchExact
-        OrderDirection = $OrderDirection
-        MatchContains  = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sc_req_item'
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'sc_req_item'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
-
-    # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
-
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
-
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-    }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
     If (-not $Properties) {
-        $Result | ForEach-Object {$_.PSObject.TypeNames.Insert(0,'ServiceNow.RequestItem')}
+        $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.RequestItem") }
     }
-    $Result
+    $result
 }

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -67,7 +67,7 @@ function Get-ServiceNowRequestItem {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sc_req_item'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sc_req_item'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.RequestItem") }

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -19,33 +19,33 @@ function Get-ServiceNowRequestItem {
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     param(
         # Machine name of the field to order by
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
@@ -69,7 +69,7 @@ function Get-ServiceNowRequestItem {
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sc_req_item'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.RequestItem") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -19,30 +19,30 @@ function Get-ServiceNowTable {
         # Name of the table we're querying (e.g. incidents)
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$Table,
+        [string] $Table,
 
         # sysparm_query param in the format of a ServiceNow encoded query string (see http://wiki.servicenow.com/index.php?title=Encoded_Query_Strings)
         [Parameter(Mandatory = $false)]
-        [string]$Query,
+        [string] $Query,
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit,
+        [int] $Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
         [Alias('Fields')]
-        [string[]]$Properties,
+        [string[]] $Properties,
 
         # Whether or not to show human readable display values instead of machine values
         [Parameter(Mandatory = $false)]
         [ValidateSet('true', 'false', 'all')]
-        [string]$DisplayValues = 'true',
+        [string] $DisplayValues = 'true',
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
-        [PSCredential]$Credential,
+        [PSCredential] $Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -58,14 +58,6 @@ function Get-ServiceNowTable {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $newServiceNowQuerySplat = @{
-        OrderBy        = $OrderBy
-        OrderDirection = $OrderDirection
-        MatchExact     = $MatchExact
-        MatchContains  = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
-
     # Table Splat
     $getServiceNowTableSplat = @{
         Table             = $Table
@@ -78,16 +70,15 @@ function Get-ServiceNowTable {
         ServiceNowSession = $ServiceNowSession
     }
 
-    # Only add the Limit parameter if it was explicitly provided
+    # # Only add the Limit parameter if it was explicitly provided
     if ($PSBoundParameters.ContainsKey('Limit')) {
         $getServiceNowTableSplat.Add('Limit', $Limit)
     }
 
-    # Add all provided paging parameters
+    # # Add all provided paging parameters
     ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
         $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
-    Write-Verbose ($getServiceNowTableSplat | Out-String)
     Invoke-ServiceNowRestMethod @getServiceNowTableSplat
 }

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -17,39 +17,39 @@ function Get-ServiceNowTable {
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param (
         # Name of the table we're querying (e.g. incidents)
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string] $Table,
 
         # sysparm_query param in the format of a ServiceNow encoded query string (see http://wiki.servicenow.com/index.php?title=Encoded_Query_Strings)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string] $Query,
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int] $Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]] $Properties,
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string] $DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential] $Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Connection,
 

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -14,7 +14,7 @@ function Get-ServiceNowTable {
 #>
 
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param (
         # Name of the table we're querying (e.g. incidents)
         [parameter(Mandatory = $true)]
@@ -88,5 +88,6 @@ function Get-ServiceNowTable {
         $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
+    Write-Verbose ($getServiceNowTableSplat | Out-String)
     Invoke-ServiceNowRestMethod @getServiceNowTableSplat
 }

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -1,5 +1,5 @@
 function Get-ServiceNowTable {
-<#
+    <#
     .SYNOPSIS
         Retrieves records for the specified table
     .DESCRIPTION
@@ -51,114 +51,42 @@ function Get-ServiceNowTable {
 
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Get credential and ServiceNow REST URL
-    if ($null -ne $Connection) {
-        $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-        $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-        $ServiceNowURL = 'https://' + $Connection.ServiceNowUri + '/api/now/v1'
+    $newServiceNowQuerySplat = @{
+        OrderBy        = $OrderBy
+        OrderDirection = $OrderDirection
+        MatchExact     = $MatchExact
+        MatchContains  = $MatchContains
     }
-    elseif ($null -ne $Credential -and $null -ne $ServiceNowURL) {
-        Try {
-            $null = Test-ServiceNowURL -Url $ServiceNowURL -ErrorAction Stop
-            $ServiceNowURL = 'https://' + $ServiceNowURL + '/api/now/v1'
-        }
-        Catch {
-            Throw $PSItem
-        }
-    }
-    elseif ((Test-ServiceNowAuthIsSet)) {
-        $Credential = $Global:ServiceNowCredentials
-        $ServiceNowURL = $global:ServiceNowRESTURL
-    }
-    else {
-        throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+
+    # Table Splat
+    $getServiceNowTableSplat = @{
+        Table             = $Table
+        Query             = $Query
+        Fields            = $Properties
+        DisplayValues     = $DisplayValues
+        Connection        = $Connection
+        Credential        = $Credential
+        ServiceNowUrl     = $ServiceNowURL
+        ServiceNowSession = $ServiceNowSession
     }
 
-    $Body = @{'sysparm_display_value' = $DisplayValues}
-
-    # Handle paging parameters
-    # If -Limit was provided, write a warning message, but prioritize it over -First.
-    # The value of -First defaults to [uint64]::MaxValue if not specified.
-    # If no paging information was provided, default to the legacy behavior, which was to return 10 records.
-
+    # Only add the Limit parameter if it was explicitly provided
     if ($PSBoundParameters.ContainsKey('Limit')) {
-        Write-Warning "The -Limit parameter is deprecated, and may be removed in a future release. Use the -First parameter instead."
-        $Body['sysparm_limit'] = $Limit
-    }
-    elseif ($PSCmdlet.PagingParameters.First -ne [uint64]::MaxValue) {
-        $Body['sysparm_limit'] = $PSCmdlet.PagingParameters.First
-    }
-    else {
-        $Body['sysparm_limit'] = 10
+        $getServiceNowTableSplat.Add('Limit', $Limit)
     }
 
-    if ($PSCmdlet.PagingParameters.Skip) {
-        $Body['sysparm_offset'] = $PSCmdlet.PagingParameters.Skip
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | ForEach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
-    if ($PSCmdlet.PagingParameters.IncludeTotalCount) {
-        # Accuracy is a double between 0.0 and 1.0 representing an estimated percentage accuracy.
-        # 0.0 means we have no idea and 1.0 means the number is exact.
-
-        # ServiceNow does return this information in the X-Total-Count response header,
-        # but we're currently using Invoke-RestMethod to perform the API call, and Invoke-RestMethod
-        # does not provide the response headers, so we can't capture this info.
-
-        # To properly support this parameter, we'd need to fall back on Invoke-WebRequest, read the
-        # X-Total-Count header of the response, and update this parameter after performing the API
-        # call.
-
-        # Reference:
-        # https://developer.servicenow.com/app.do#!/rest_api_doc?v=jakarta&id=r_TableAPI-GET
-
-        [double] $accuracy = 0.0
-        $PSCmdlet.PagingParameters.NewTotalCount($PSCmdlet.PagingParameters.First, $accuracy)
-    }
-
-    # Populate the query
-    if ($Query) {
-        $Body.sysparm_query = $Query
-    }
-
-    if ($Properties) {
-        $Body.sysparm_fields = ($Properties -join ',').ToLower()
-    }
-
-    # Perform table query and capture results
-    $Uri = $ServiceNowURL + "/table/$Table"
-    $Result = (Invoke-RestMethod -Uri $Uri -Credential $Credential -Body $Body -ContentType "application/json").Result
-
-    # Convert specific fields to DateTime format
-    $ConvertToDateField = @('closed_at', 'expected_start', 'follow_up', 'opened_at', 'sys_created_on', 'sys_updated_on', 'work_end', 'work_start')
-    ForEach ($SNResult in $Result) {
-        ForEach ($Property in $ConvertToDateField) {
-            If (-not [string]::IsNullOrEmpty($SNResult.$Property)) {
-                Try {
-                    # Extract the default Date/Time formatting from the local computer's "Culture" settings, and then create the format to use when parsing the date/time from Service-Now
-                    $CultureDateTimeFormat = (Get-Culture).DateTimeFormat
-                    $DateFormat = $CultureDateTimeFormat.ShortDatePattern
-                    $TimeFormat = $CultureDateTimeFormat.LongTimePattern
-                    $DateTimeFormat = "$DateFormat $TimeFormat"
-                    $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DateTimeFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo, [System.Globalization.DateTimeStyles]::None)
-                }
-                Catch {
-                    Try {
-                        # Universal Format
-                        $DateTimeFormat = 'yyyy-MM-dd HH:mm:ss'
-                        $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DateTimeFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo, [System.Globalization.DateTimeStyles]::None)
-                    }
-                    Catch {
-                        # If the local culture and universal formats both fail keep the property as a string (Do nothing)
-                        $null = 'Silencing a PSSA alert with this line'
-                    }
-                }
-            }
-        }
-    }
-
-    # Return the results
-    $Result
+    Invoke-ServiceNowRestMethod @getServiceNowTableSplat
 }

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -62,7 +62,7 @@ function Get-ServiceNowTableEntry {
         [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
-        [ValidateScript( { Test-ServiceNowURL -Url $_ })]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
@@ -89,5 +89,6 @@ function Get-ServiceNowTableEntry {
     $paramsWithoutQuery.Remove('OrderDirection') | Out-Null
     $paramsWithoutQuery.Remove('MatchContains') | Out-Null
 
-    Get-ServiceNowTable @paramsWithoutQuery -Query $query
+    Invoke-ServiceNowRestMethod @paramsWithoutQuery -Query $query
+    # Get-ServiceNowTable @paramsWithoutQuery -Query $query
 }

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -62,7 +62,7 @@ function Get-ServiceNowTableEntry {
         [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [ValidateScript( { Test-ServiceNowURL -Url $_ })]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
@@ -75,5 +75,19 @@ function Get-ServiceNowTableEntry {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    Get-ServiceNowTable @PSBoundParameters -Table $Table
+    $newServiceNowQuerySplat = @{
+        OrderBy        = $OrderBy
+        MatchExact     = $MatchExact
+        OrderDirection = $OrderDirection
+        MatchContains  = $MatchContains
+    }
+    $query = New-ServiceNowQuery @newServiceNowQuerySplat
+
+    $paramsWithoutQuery = $PSBoundParameters
+    $paramsWithoutQuery.Remove('OrderBy') | Out-Null
+    $paramsWithoutQuery.Remove('MatchExact') | Out-Null
+    $paramsWithoutQuery.Remove('OrderDirection') | Out-Null
+    $paramsWithoutQuery.Remove('MatchContains') | Out-Null
+
+    Get-ServiceNowTable @paramsWithoutQuery -Query $query
 }

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -22,103 +22,58 @@ function Get-ServiceNowTableEntry {
     [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     param(
         # Table containing the entry we're deleting
-        [parameter(mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Table,
 
         # Machine name of the field to order by
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateScript({Test-ServiceNowURL -Url $_})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    Try {
-        # Query Splat
-        $newServiceNowQuerySplat = @{
-            OrderBy        = $OrderBy
-            MatchExact     = $MatchExact
-            OrderDirection = $OrderDirection
-            MatchContains  = $MatchContains
-            ErrorAction    = 'Stop'
-        }
-        $Query = New-ServiceNowQuery @newServiceNowQuerySplat
-
-        # Table Splat
-        $getServiceNowTableSplat = @{
-            Table         = $Table
-            Query         = $Query
-            Fields        = $Properties
-            DisplayValues = $DisplayValues
-            ErrorAction   = 'Stop'
-        }
-
-        # Update the Table Splat if an applicable parameter set name is in use
-        Switch ($PSCmdlet.ParameterSetName) {
-            'SpecifyConnectionFields' {
-                $getServiceNowTableSplat.Add('Credential', $Credential)
-                $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-                break
-            }
-            'UseConnectionObject' {
-                $getServiceNowTableSplat.Add('Connection', $Connection)
-                break
-            }
-            Default {}
-        }
-
-        # Only add the Limit parameter if it was explicitly provided
-        if ($PSBoundParameters.ContainsKey('Limit')) {
-            $getServiceNowTableSplat.Add('Limit', $Limit)
-        }
-
-        # Add all provided paging parameters
-        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-            $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-        }
-
-        # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties
-        Get-ServiceNowTable @getServiceNowTableSplat
-    }
-    Catch {
-        Write-Error $PSItem
-    }
+    Get-ServiceNowTable @PSBoundParameters -Table $Table
 }

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowUser{
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -45,49 +45,17 @@ function Get-ServiceNowUser{
 
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy        = $OrderBy
-        OrderDirection = $OrderDirection
-        MatchExact     = $MatchExact
-        MatchContains  = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sys_user'
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'sys_user'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
-
-    # Update the splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
-
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
-
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-    }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
     If (-not $Properties) {
-        $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.UserAndUserGroup")}
+        $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.UserAndUserGroup") }
     }
-    $Result
+    $result
 }

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -52,7 +52,7 @@ function Get-ServiceNowUser{
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sys_user'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sys_user'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.UserAndUserGroup") }

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -3,47 +3,47 @@ function Get-ServiceNowUser{
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string]$OrderBy = 'name',
 
         # Direction of ordering (Desc/Asc)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript({$_ | Test-ServiceNowURL})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Connection,
 
@@ -54,7 +54,7 @@ function Get-ServiceNowUser{
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sys_user'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.UserAndUserGroup") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -3,47 +3,47 @@ function Get-ServiceNowUserGroup{
     [CmdletBinding(DefaultParameterSetName='Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [string]$OrderBy = 'name',
 
         # Direction of ordering (Desc/Asc)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [int]$Limit,
 
         # Fields to return
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Alias('Fields')]
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript({$_ | Test-ServiceNowURL})]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Connection,
 
@@ -54,7 +54,7 @@ function Get-ServiceNowUserGroup{
 
     $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sys_user_group'
 
-    If (-not $Properties) {
+    If ( $result -and -not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.UserAndUserGroup") }
     }
     $result

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -52,7 +52,7 @@ function Get-ServiceNowUserGroup{
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sys_user_group'
+    $result = Get-ServiceNowTableEntry @PSBoundParameters -Table 'sys_user_group'
 
     If (-not $Properties) {
         $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.UserAndUserGroup") }

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowUserGroup{
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
+    [CmdletBinding(DefaultParameterSetName='Session', SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -45,49 +45,17 @@ function Get-ServiceNowUserGroup{
 
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$Connection
+        [hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy        = $OrderBy
-        OrderDirection = $OrderDirection
-        MatchExact     = $MatchExact
-        MatchContains  = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    $result = Get-ServiceNowTable @PSBoundParameters -Table 'sys_user_group'
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'sys_user_group'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
-
-    # Update the splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
-
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
-
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
-    }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
     If (-not $Properties) {
-        $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.UserAndUserGroup")}
+        $result | ForEach-Object { $_.PSObject.TypeNames.Insert(0, "ServiceNow.UserAndUserGroup") }
     }
-    $Result
+    $result
 }

--- a/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
@@ -73,7 +73,8 @@ function New-ServiceNowChangeRequest {
         New-ServiceNowChangeRequest @newServiceNowChangeRequestSplat
      #>
 
-    [CmdletBinding(DefaultParameterSetName, SupportsShouldProcess)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
+
     Param(
         [parameter(Mandatory)]
         [string]$Caller,
@@ -118,12 +119,11 @@ function New-ServiceNowChangeRequest {
         [ValidateNotNullOrEmpty()]
         [hashtable] $ServiceNowSession = $script:ServiceNowSession,
 
-        # Switch to allow the results to be passed back
         [Parameter()]
         [switch] $PassThru
     )
 
-    begin { }
+    begin {}
 
     process {
         # Create a hash table of any defined parameters (not CustomFields) that have values
@@ -176,12 +176,13 @@ function New-ServiceNowChangeRequest {
             ServiceNowSession = $ServiceNowSession
         }
 
-        If ($PSCmdlet.ShouldProcess($Uri, $MyInvocation.MyCommand)) {
-            $result = Invoke-ServiceNowRestMethod @params
+        If ( $PSCmdlet.ShouldProcess($ShortDescription, 'Create new change request') ) {
+            $response = Invoke-ServiceNowRestMethod @params
             If ($PassThru.IsPresent) {
-                $result
+                $response
             }
         }
     }
-    end { }
+
+    end {}
 }

--- a/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
@@ -120,10 +120,11 @@ function New-ServiceNowChangeRequest {
 
         # Switch to allow the results to be passed back
         [Parameter()]
-        [switch]$PassThru
+        [switch] $PassThru
     )
 
     begin { }
+
     process {
         # Create a hash table of any defined parameters (not CustomFields) that have values
         $DefinedChangeRequestParameters = @('AssignmentGroup', 'Caller', 'Category', 'Comment', 'ConfigurationItem', 'Description', 'ShortDescription', 'Subcategory')

--- a/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
@@ -75,120 +75,111 @@ function New-ServiceNowChangeRequest {
 
     [CmdletBinding(DefaultParameterSetName, SupportsShouldProcess)]
     Param(
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Caller,
 
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$ShortDescription,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$Description,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$AssignmentGroup,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$Comment,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$Category,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$Subcategory,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [string]$ConfigurationItem,
 
-        [parameter(Mandatory = $false)]
+        [parameter()]
         [hashtable]$CustomFields,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [PSCredential]$ServiceNowCredential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Hashtable]$Connection,
 
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
         # Switch to allow the results to be passed back
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [switch]$PassThru
     )
 
     begin { }
     process {
-        Try {
-            # Create a hash table of any defined parameters (not CustomFields) that have values
-            $DefinedChangeRequestParameters = @('AssignmentGroup', 'Caller', 'Category', 'Comment', 'ConfigurationItem', 'Description', 'ShortDescription', 'Subcategory')
-            $TableEntryValues = @{ }
-            ForEach ($Parameter in $DefinedChangeRequestParameters) {
-                If ($null -ne $PSBoundParameters.$Parameter) {
-                    # Turn the defined parameter name into the ServiceNow attribute name
-                    $KeyToAdd = Switch ($Parameter) {
-                        AssignmentGroup   {'assignment_group'; break}
-                        Caller            {'caller_id'; break}
-                        Category          {'category'; break}
-                        Comment           {'comments'; break}
-                        ConfigurationItem {'cmdb_ci'; break}
-                        Description       {'description'; break}
-                        ShortDescription  {'short_description'; break}
-                        Subcategory       {'subcategory'; break}
-                    }
-                    $TableEntryValues.Add($KeyToAdd, $PSBoundParameters.$Parameter)
+        # Create a hash table of any defined parameters (not CustomFields) that have values
+        $DefinedChangeRequestParameters = @('AssignmentGroup', 'Caller', 'Category', 'Comment', 'ConfigurationItem', 'Description', 'ShortDescription', 'Subcategory')
+        $TableEntryValues = @{ }
+        ForEach ($Parameter in $DefinedChangeRequestParameters) {
+            If ($null -ne $PSBoundParameters.$Parameter) {
+                # Turn the defined parameter name into the ServiceNow attribute name
+                $KeyToAdd = Switch ($Parameter) {
+                    AssignmentGroup { 'assignment_group'; break }
+                    Caller { 'caller_id'; break }
+                    Category { 'category'; break }
+                    Comment { 'comments'; break }
+                    ConfigurationItem { 'cmdb_ci'; break }
+                    Description { 'description'; break }
+                    ShortDescription { 'short_description'; break }
+                    Subcategory { 'subcategory'; break }
                 }
+                $TableEntryValues.Add($KeyToAdd, $PSBoundParameters.$Parameter)
             }
+        }
 
-            # Add CustomFields hash pairs to the Table Entry Values hash table
-            If ($null -ne $PSBoundParameters.CustomFields) {
-                $DuplicateTableEntryValues = ForEach ($Key in $CustomFields.Keys) {
-                    If (($TableEntryValues.ContainsKey($Key) -eq $False)) {
-                        # Add the unique entry to the table entry values hash table
-                        $TableEntryValues.Add($Key, $CustomFields[$Key])
-                    }
-                    Else {
-                        # Capture the duplicate key name
-                        $Key
-                    }
-                }
-            }
-
-            # Throw an error if duplicate fields were provided
-            If ($null -ne $DuplicateTableEntryValues) {
-                $DuplicateKeyList = $DuplicateTableEntryValues -join ","
-                Throw "Ticket fields may only be used once:  $DuplicateKeyList"
-            }
-
-            # Table Entry Splat
-            $newServiceNowTableEntrySplat = @{
-                Table  = 'change_request'
-                Values = $TableEntryValues
-            }
-
-            # Update the splat if the parameters have values
-            If ($null -ne $PSBoundParameters.Connection) {
-                $newServiceNowTableEntrySplat.Add('Connection', $Connection)
-            }
-            ElseIf ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-                $newServiceNowTableEntrySplat.Add('ServiceNowCredential', $ServiceNowCredential)
-                $newServiceNowTableEntrySplat.Add('ServiceNowURL', $ServiceNowURL)
-            }
-
-            # Create the table entry
-            If ($PSCmdlet.ShouldProcess($Uri, $MyInvocation.MyCommand)) {
-                $Result = New-ServiceNowTableEntry @newServiceNowTableEntrySplat
-
-                # Option to return results
-                If ($PSBoundParameters.ContainsKey('Passthru')) {
-                    $Result
+        # Add CustomFields hash pairs to the Table Entry Values hash table
+        If ($null -ne $PSBoundParameters.CustomFields) {
+            $DuplicateTableEntryValues = ForEach ($Key in $CustomFields.Keys) {
+                If (($TableEntryValues.ContainsKey($Key) -eq $False)) {
+                    # Add the unique entry to the table entry values hash table
+                    $TableEntryValues.Add($Key, $CustomFields[$Key])
+                } Else {
+                    # Capture the duplicate key name
+                    $Key
                 }
             }
         }
-        Catch {
-            Write-Error $PSItem
+
+        # Throw an error if duplicate fields were provided
+        If ($null -ne $DuplicateTableEntryValues) {
+            $DuplicateKeyList = $DuplicateTableEntryValues -join ","
+            Throw "Ticket fields may only be used once:  $DuplicateKeyList"
+        }
+
+        # Table Entry Splat
+        $params = @{
+            Method            = 'Post'
+            Table             = 'change_request'
+            Values            = $TableEntryValues
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        If ($PSCmdlet.ShouldProcess($Uri, $MyInvocation.MyCommand)) {
+            $result = Invoke-ServiceNowRestMethod @params
+            If ($PassThru.IsPresent) {
+                $result
+            }
         }
     }
     end { }

--- a/ServiceNow/Public/New-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/New-ServiceNowIncident.ps1
@@ -35,55 +35,55 @@ function New-ServiceNowIncident {
 
         # sys_id of the caller of the incident (user Get-ServiceNowUser to retrieve this)
         [parameter(Mandatory)]
-        [string]$Caller,
+        [string] $Caller,
 
         # Short description of the incident
         [parameter(Mandatory)]
-        [string]$ShortDescription,
+        [string] $ShortDescription,
 
         # Long description of the incident
         [parameter()]
-        [string]$Description,
+        [string] $Description,
 
         # sys_id of the assignment group (use Get-ServiceNowUserGroup to retrieve this)
         [parameter()]
-        [string]$AssignmentGroup,
+        [string] $AssignmentGroup,
 
         # Comment to include in the ticket
         [parameter()]
-        [string]$Comment,
+        [string] $Comment,
 
         # Category of the incident (e.g. 'Network')
         [parameter()]
-        [string]$Category,
+        [string] $Category,
 
         # Subcategory of the incident (e.g. 'Network')
         [parameter()]
-        [string]$Subcategory,
+        [string] $Subcategory,
 
         # sys_id of the configuration item of the incident
         [parameter()]
-        [string]$ConfigurationItem,
+        [string] $ConfigurationItem,
 
         # custom fields as hashtable
         [parameter()]
-        [hashtable]$CustomFields,
+        [hashtable] $CustomFields,
 
         # Credential used to authenticate to ServiceNow
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
-        [PSCredential]$Credential,
+        [PSCredential] $Credential,
 
         # The URL for the ServiceNow instance being used (eg: instancename.service-now.com)
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$ServiceNowURL,
+        [string] $ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection,
+        [Hashtable] $Connection,
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
@@ -140,18 +140,5 @@ function New-ServiceNowIncident {
         ServiceNowSession = $ServiceNowSession
     }
 
-    # Update the splat if the parameters have values
-    # if ($null -ne $PSBoundParameters.Connection)
-    # {
-    #     $newServiceNowTableEntrySplat.Add('Connection',$Connection)
-    # }
-    # elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL)
-    # {
-    #     $newServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
-    #     $newServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)
-    # }
-
-    # # Create the table entry
-    # New-ServiceNowTableEntry @newServiceNowTableEntrySplat
     Invoke-ServiceNowRestMethod @params
 }

--- a/ServiceNow/Public/New-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/New-ServiceNowIncident.ps1
@@ -31,6 +31,8 @@ Generate an Incident by "Splatting" all fields used in the 1st example plus some
 #>
 function New-ServiceNowIncident {
 
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
+
     Param(
 
         # sys_id of the caller of the incident (user Get-ServiceNowUser to retrieve this)
@@ -87,12 +89,13 @@ function New-ServiceNowIncident {
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [switch] $PassThru
     )
 
-    begin {
-        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
-    }
+    begin {}
 
     process {
         # Create a hash table of any defined parameters (not CustomFields) that have values
@@ -145,6 +148,11 @@ function New-ServiceNowIncident {
             ServiceNowSession = $ServiceNowSession
         }
 
-        Invoke-ServiceNowRestMethod @params
+        If ( $PSCmdlet.ShouldProcess($ShortDescription, 'Create new incident') ) {
+            $response = Invoke-ServiceNowRestMethod @params
+            If ($PassThru.IsPresent) {
+                $response
+            }
+        }
     }
 }

--- a/ServiceNow/Public/New-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/New-ServiceNowIncident.ps1
@@ -90,55 +90,61 @@ function New-ServiceNowIncident {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    # Create a hash table of any defined parameters (not CustomFields) that have values
-    $DefinedIncidentParameters = @('AssignmentGroup', 'Caller', 'Category', 'Comment', 'ConfigurationItem', 'Description', 'ShortDescription', 'Subcategory')
-    $TableEntryValues = @{}
-    ForEach ($Parameter in $DefinedIncidentParameters) {
-        If ($null -ne $PSBoundParameters.$Parameter) {
-            # Turn the defined parameter name into the ServiceNow attribute name
-            $KeyToAdd = Switch ($Parameter) {
-                AssignmentGroup { 'assignment_group'; break }
-                Caller { 'caller_id'; break }
-                Category { 'category'; break }
-                Comment { 'comments'; break }
-                ConfigurationItem { 'cmdb_ci'; break }
-                Description { 'description'; break }
-                ShortDescription { 'short_description'; break }
-                Subcategory { 'subcategory'; break }
-            }
-            $TableEntryValues.Add($KeyToAdd, $PSBoundParameters.$Parameter)
-        }
+    begin {
+        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
     }
 
-    # Add CustomFields hash pairs to the Table Entry Values hash table
-    If ($null -ne $PSBoundParameters.CustomFields) {
-        $DuplicateTableEntryValues = ForEach ($Key in $CustomFields.Keys) {
-            If (($TableEntryValues.ContainsKey($Key) -eq $False)) {
-                # Add the unique entry to the table entry values hash table
-                $TableEntryValues.Add($Key, $CustomFields[$Key])
-            } Else {
-                # Capture the duplicate key name
-                $Key
+    process {
+        # Create a hash table of any defined parameters (not CustomFields) that have values
+        $DefinedIncidentParameters = @('AssignmentGroup', 'Caller', 'Category', 'Comment', 'ConfigurationItem', 'Description', 'ShortDescription', 'Subcategory')
+        $TableEntryValues = @{}
+        ForEach ($Parameter in $DefinedIncidentParameters) {
+            If ($null -ne $PSBoundParameters.$Parameter) {
+                # Turn the defined parameter name into the ServiceNow attribute name
+                $KeyToAdd = Switch ($Parameter) {
+                    AssignmentGroup { 'assignment_group'; break }
+                    Caller { 'caller_id'; break }
+                    Category { 'category'; break }
+                    Comment { 'comments'; break }
+                    ConfigurationItem { 'cmdb_ci'; break }
+                    Description { 'description'; break }
+                    ShortDescription { 'short_description'; break }
+                    Subcategory { 'subcategory'; break }
+                }
+                $TableEntryValues.Add($KeyToAdd, $PSBoundParameters.$Parameter)
             }
         }
-    }
 
-    # Throw an error if duplicate fields were provided
-    If ($null -ne $DuplicateTableEntryValues) {
-        $DuplicateKeyList = $DuplicateTableEntryValues -join ","
-        Throw "Ticket fields may only be used once:  $DuplicateKeyList"
-    }
+        # Add CustomFields hash pairs to the Table Entry Values hash table
+        If ($null -ne $PSBoundParameters.CustomFields) {
+            $DuplicateTableEntryValues = ForEach ($Key in $CustomFields.Keys) {
+                If (($TableEntryValues.ContainsKey($Key) -eq $False)) {
+                    # Add the unique entry to the table entry values hash table
+                    $TableEntryValues.Add($Key, $CustomFields[$Key])
+                } Else {
+                    # Capture the duplicate key name
+                    $Key
+                }
+            }
+        }
 
-    # Table Entry Splat
-    $params = @{
-        Method            = 'Post'
-        Table             = 'incident'
-        Values            = $TableEntryValues
-        Connection        = $Connection
-        Credential        = $Credential
-        ServiceNowUrl     = $ServiceNowURL
-        ServiceNowSession = $ServiceNowSession
-    }
+        # Throw an error if duplicate fields were provided
+        If ($null -ne $DuplicateTableEntryValues) {
+            $DuplicateKeyList = $DuplicateTableEntryValues -join ","
+            Throw "Ticket fields may only be used once:  $DuplicateKeyList"
+        }
 
-    Invoke-ServiceNowRestMethod @params
+        # Table Entry Splat
+        $params = @{
+            Method            = 'Post'
+            Table             = 'incident'
+            Values            = $TableEntryValues
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        Invoke-ServiceNowRestMethod @params
+    }
 }

--- a/ServiceNow/Public/New-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/New-ServiceNowIncident.ps1
@@ -1,134 +1,112 @@
-function New-ServiceNowIncident{
 <#
 .SYNOPSIS
-    Generates a new ServiceNow Incident
+Generates a new ServiceNow Incident
 
 .DESCRIPTION
-    Generates a new ServiceNow Incident using predefined or custom fields by invoking the ServiceNow API
+Generates a new ServiceNow Incident using predefined or custom fields by invoking the ServiceNow API
 
 .LINK
-    https://github.com/Snow-Shell/servicenow-powershell
+https://github.com/Snow-Shell/servicenow-powershell
 
 .EXAMPLE
-    Generate a basic Incident attributed to the caller "UserName" with descriptions, categories, assignment groups and CMDB items set.
-        New-ServiceNowIncident -Caller "UserName" -ShortDescription = "New PS Incident" -Description = "This incident was created from Powershell" -AssignmentGroup "ServiceDesk" -Comment "Inline Comment" -Category "Office" -Subcategory "Outlook" -ConfigurationItem UserPC1
+Generate a basic Incident attributed to the caller "UserName" with descriptions, categories, assignment groups and CMDB items set.
+    New-ServiceNowIncident -Caller "UserName" -ShortDescription = "New PS Incident" -Description = "This incident was created from Powershell" -AssignmentGroup "ServiceDesk" -Comment "Inline Comment" -Category "Office" -Subcategory "Outlook" -ConfigurationItem UserPC1
 
 .EXAMPLE
-    Generate an Incident by "Splatting" all fields used in the 1st example plus some additional custom ServiceNow fields (These must exist in your ServiceNow Instance):
+Generate an Incident by "Splatting" all fields used in the 1st example plus some additional custom ServiceNow fields (These must exist in your ServiceNow Instance):
 
-        $IncidentParams = @{Caller = "UserName"
-            ShortDescription = "New PS Incident"
-            Description = "This incident was created from Powershell"
-            AssignmentGroup "ServiceDesk"
-            Comment "Inline Comment"
-            Category "Office"
-            Subcategory "Outlook"
-            ConfigurationItem UserPC1
-            CustomFields = @{u_custom1 = "Custom Field Entry"
-                            u_another_custom = "Related Test"}
-            }
-        New-ServiceNowIncident @Params
+    $IncidentParams = @{Caller = "UserName"
+        ShortDescription = "New PS Incident"
+        Description = "This incident was created from Powershell"
+        AssignmentGroup "ServiceDesk"
+        Comment "Inline Comment"
+        Category "Office"
+        Subcategory "Outlook"
+        ConfigurationItem UserPC1
+        CustomFields = @{u_custom1 = "Custom Field Entry"
+                        u_another_custom = "Related Test"}
+        }
+    New-ServiceNowIncident @Params
 
- #>
+#>
+function New-ServiceNowIncident {
 
     Param(
 
         # sys_id of the caller of the incident (user Get-ServiceNowUser to retrieve this)
-        [parameter(Mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter(Mandatory)]
         [string]$Caller,
 
         # Short description of the incident
-        [parameter(Mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter(Mandatory)]
         [string]$ShortDescription,
 
         # Long description of the incident
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [string]$Description,
 
         # sys_id of the assignment group (use Get-ServiceNowUserGroup to retrieve this)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [string]$AssignmentGroup,
 
         # Comment to include in the ticket
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [string]$Comment,
 
         # Category of the incident (e.g. 'Network')
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [string]$Category,
 
         # Subcategory of the incident (e.g. 'Network')
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [string]$Subcategory,
 
         # sys_id of the configuration item of the incident
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [string]$ConfigurationItem,
 
         # custom fields as hashtable
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter()]
         [hashtable]$CustomFields,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]$ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
         # The URL for the ServiceNow instance being used (eg: instancename.service-now.com)
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection
+        [Hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
     # Create a hash table of any defined parameters (not CustomFields) that have values
-    $DefinedIncidentParameters = @('AssignmentGroup','Caller','Category','Comment','ConfigurationItem','Description','ShortDescription','Subcategory')
+    $DefinedIncidentParameters = @('AssignmentGroup', 'Caller', 'Category', 'Comment', 'ConfigurationItem', 'Description', 'ShortDescription', 'Subcategory')
     $TableEntryValues = @{}
     ForEach ($Parameter in $DefinedIncidentParameters) {
         If ($null -ne $PSBoundParameters.$Parameter) {
             # Turn the defined parameter name into the ServiceNow attribute name
             $KeyToAdd = Switch ($Parameter) {
-                AssignmentGroup     {'assignment_group'; break}
-                Caller              {'caller_id'; break}
-                Category            {'category'; break}
-                Comment             {'comments'; break}
-                ConfigurationItem   {'cmdb_ci'; break}
-                Description         {'description'; break}
-                ShortDescription    {'short_description'; break}
-                Subcategory         {'subcategory'; break}
+                AssignmentGroup { 'assignment_group'; break }
+                Caller { 'caller_id'; break }
+                Category { 'category'; break }
+                Comment { 'comments'; break }
+                ConfigurationItem { 'cmdb_ci'; break }
+                Description { 'description'; break }
+                ShortDescription { 'short_description'; break }
+                Subcategory { 'subcategory'; break }
             }
-            $TableEntryValues.Add($KeyToAdd,$PSBoundParameters.$Parameter)
+            $TableEntryValues.Add($KeyToAdd, $PSBoundParameters.$Parameter)
         }
     }
 
@@ -137,9 +115,8 @@ function New-ServiceNowIncident{
         $DuplicateTableEntryValues = ForEach ($Key in $CustomFields.Keys) {
             If (($TableEntryValues.ContainsKey($Key) -eq $False)) {
                 # Add the unique entry to the table entry values hash table
-                $TableEntryValues.Add($Key,$CustomFields[$Key])
-            }
-            Else {
+                $TableEntryValues.Add($Key, $CustomFields[$Key])
+            } Else {
                 # Capture the duplicate key name
                 $Key
             }
@@ -153,22 +130,28 @@ function New-ServiceNowIncident{
     }
 
     # Table Entry Splat
-    $newServiceNowTableEntrySplat = @{
-        Table = 'incident'
-        Values = $TableEntryValues
+    $params = @{
+        Method            = 'Post'
+        Table             = 'incident'
+        Values            = $TableEntryValues
+        Connection        = $Connection
+        Credential        = $Credential
+        ServiceNowUrl     = $ServiceNowURL
+        ServiceNowSession = $ServiceNowSession
     }
 
     # Update the splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection)
-    {
-        $newServiceNowTableEntrySplat.Add('Connection',$Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL)
-    {
-        $newServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
-        $newServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)
-    }
+    # if ($null -ne $PSBoundParameters.Connection)
+    # {
+    #     $newServiceNowTableEntrySplat.Add('Connection',$Connection)
+    # }
+    # elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL)
+    # {
+    #     $newServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
+    #     $newServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)
+    # }
 
-    # Create the table entry
-    New-ServiceNowTableEntry @newServiceNowTableEntrySplat
+    # # Create the table entry
+    # New-ServiceNowTableEntry @newServiceNowTableEntrySplat
+    Invoke-ServiceNowRestMethod @params
 }

--- a/ServiceNow/Public/New-ServiceNowQuery.ps1
+++ b/ServiceNow/Public/New-ServiceNowQuery.ps1
@@ -26,20 +26,20 @@ function New-ServiceNowQuery {
 
     param(
         # Machine name of the field to order by
-        [parameter(mandatory=$false)]
+        [parameter()]
         [string]$OrderBy='opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$false)]
+        [parameter()]
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$false)]
+        [parameter()]
         [hashtable]$MatchExact,
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$false)]
+        [parameter()]
         [hashtable]$MatchContains
     )
 

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -6,6 +6,7 @@ Create a new ServiceNow session
 Create a new ServiceNow session via credentials, OAuth, or access token.
 This session will be used by default for all future calls.
 Optionally, you can specify the api version you'd like to use; the default is the latest.
+To use OAuth, ensure you've set it up, https://docs.servicenow.com/bundle/quebec-platform-administration/page/administer/security/task/t_SettingUpOAuth.html.
 
 .PARAMETER Url
 Base domain for your ServiceNow instance, eg. tenant.domain.com
@@ -25,6 +26,31 @@ Specific API version to use.  The default is the latest.
 .PARAMETER PassThru
 Provide the resulting session object to the pipeline as opposed to setting as a script scoped variable to be used by default for other calls.
 This is useful if you want to have multiple sessions with different api versions, credentials, etc.
+
+.EXAMPLE
+New-ServiceNowSession -Url tenant.domain.com -Credential $mycred
+Create a session using basic authentication and save it to a script-scoped variable
+
+.EXAMPLE
+New-ServiceNowSession -Url tenant.domain.com -Credential $mycred -ClientCredential $myClientCred
+Create a session using OAuth and save it to a script-scoped variable
+
+.EXAMPLE
+New-ServiceNowSession -Url tenant.domain.com -AccessToken 'asdfasd9f87adsfkksk3nsnd87g6s'
+Create a session with an existing access token and save it to a script-scoped variable
+
+.EXAMPLE
+$session = New-ServiceNowSession -Url tenant.domain.com -Credential $mycred -ClientCredential $myClientCred -PassThru
+Create a session using OAuth and save it as a local variable to be provided to functions directly
+
+.INPUTS
+None
+
+.OUTPUTS
+Hashtable if -PassThru provided
+
+.LINK
+https://docs.servicenow.com/bundle/quebec-platform-administration/page/administer/security/reference/r_OAuthAPIRequestParameters.html
 #>
 function New-ServiceNowSession {
 

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -3,7 +3,28 @@
 Create a new ServiceNow session
 
 .DESCRIPTION
+Create a new ServiceNow session via credentials, OAuth, or access token.
+This session will be used by default for all future calls.
+Optionally, you can specify the api version you'd like to use; the default is the latest.
 
+.PARAMETER Url
+Base domain for your ServiceNow instance, eg. tenant.domain.com
+
+.PARAMETER Credential
+Username and password to connect.  This can be used standalone to use basic authentication or in conjunction with ClientCredential for OAuth.
+
+.PARAMETER ClientCredential
+Required for OAuth.  Credential where the username is the Client ID and the password is the Secret.
+
+.PARAMETER AccessToken
+Provide the access token directly if obtained outside of this module.
+
+.PARAMETER ApiVersion
+Specific API version to use.  The default is the latest.
+
+.PARAMETER PassThru
+Provide the resulting session object to the pipeline as opposed to setting as a script scoped variable to be used by default for other calls.
+This is useful if you want to have multiple sessions with different api versions, credentials, etc.
 #>
 function New-ServiceNowSession {
 
@@ -42,7 +63,7 @@ function New-ServiceNowSession {
     }
 
     $newSession = @{
-        Domain = $Url
+        Domain  = $Url
         BaseUri = ('https://{0}/api/now{1}' -f $Url, $version)
     }
 
@@ -78,7 +99,7 @@ function New-ServiceNowSession {
         }
     }
 
-    Write-Verbose ($newSession | Out-String)
+    Write-Verbose ($newSession | ConvertTo-Json)
 
     if ( $PassThru ) {
         $newSession

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -36,7 +36,13 @@ function New-ServiceNowSession {
     Write-Verbose $PSCmdLet.ParameterSetName
 
     if ( $ApiVersion -le 0 ) {
-        $version = ''
+        if ( $PSCmdLet.ParameterSetName -eq 'BasicAuth' ) {
+            # for existing users the expectation is v1 of the api, keep this for now
+            Write-Warning -Message 'A default of v1 of the API will be deprecated in favor of the latest in a future release.'
+            $version = '/v1'
+        } else {
+            $version = ''
+        }
     } else {
         $version = ('/v{0}' -f $ApiVersion)
     }

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -33,6 +33,8 @@ function New-ServiceNowSession {
         [switch] $PassThru
     )
 
+    Write-Verbose $PSCmdLet.ParameterSetName
+
     if ( $ApiVersion -le 0 ) {
         $version = ''
     } else {
@@ -75,6 +77,8 @@ function New-ServiceNowSession {
 
         }
     }
+
+    Write-Verbose ($newSession | Out-String)
 
     if ( $PassThru ) {
         $newSession

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -36,13 +36,7 @@ function New-ServiceNowSession {
     Write-Verbose $PSCmdLet.ParameterSetName
 
     if ( $ApiVersion -le 0 ) {
-        if ( $PSCmdLet.ParameterSetName -eq 'BasicAuth' ) {
-            # for existing users the expectation is v1 of the api, keep this for now
-            Write-Warning -Message 'A default of v1 of the API will be deprecated in favor of the latest in a future release.'
-            $version = '/v1'
-        } else {
-            $version = ''
-        }
+        $version = ''
     } else {
         $version = ('/v{0}' -f $ApiVersion)
     }

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+Create a new ServiceNow session
+
+.DESCRIPTION
+
+#>
+function New-ServiceNowSession {
+
+    [CmdletBinding(DefaultParameterSetName = 'BasicAuth')]
+
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
+        [Alias('ServiceNowUrl')]
+        [string] $Url,
+
+        [Parameter(Mandatory, ParameterSetName = 'BasicAuth')]
+        [Parameter(Mandatory, ParameterSetName = 'OAuth')]
+        [Alias('Credentials')]
+        [System.Management.Automation.PSCredential] $Credential,
+
+        [Parameter(Mandatory, ParameterSetName = 'OAuth')]
+        [System.Management.Automation.PSCredential] $ClientCredential,
+
+        [Parameter(Mandatory, ParameterSetName = 'AccessToken')]
+        [string] $AccessToken,
+
+        [Parameter()]
+        [int] $ApiVersion,
+
+        [Parameter()]
+        [switch] $PassThru
+    )
+
+    if ( $ApiVersion -le 0 ) {
+        $version = ''
+    } else {
+        $version = ('/v{0}' -f $ApiVersion)
+    }
+
+    $newSession = @{
+        Domain = $Url
+        BaseUri = ('https://{0}/api/now{1}' -f $Url, $version)
+    }
+
+    switch ($PSCmdLet.ParameterSetName) {
+        'OAuth' {
+            $params = @{
+                Uri    = 'https://{0}/oauth_token.do' -f $Url
+                Body   = @{
+                    'grant_type'    = 'password'
+                    'client_id'     = $ClientCredential.UserName
+                    'client_secret' = $ClientCredential.GetNetworkCredential().Password
+                    'username'      = $Credential.UserName
+                    'password'      = $Credential.GetNetworkCredential().Password
+                }
+                Method = 'Post'
+            }
+
+            $token = Invoke-RestMethod @params
+            $newSession.Add('AccessToken', $token.access_token)
+            $newSession.Add('RefreshToken', $token.refresh_token)
+        }
+        'AccessToken' {
+            $newSession.Add('AccessToken', $AccessToken)
+        }
+        'BasicAuth' {
+            $newSession.Add('Credential', $Credential)
+        }
+        'SSO' {
+
+        }
+        Default {
+
+        }
+    }
+
+    if ( $PassThru ) {
+        $newSession
+    } else {
+        $Script:ServiceNowSession = $newSession
+    }
+}

--- a/ServiceNow/Public/New-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/New-ServiceNowTableEntry.ps1
@@ -1,4 +1,7 @@
-function New-ServiceNowTableEntry{
+function New-ServiceNowTableEntry {
+
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
+
     Param
     (
         # Name of the table we're inserting into (e.g. incidents)
@@ -10,26 +13,34 @@ function New-ServiceNowTableEntry{
         [hashtable] $Values,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [PSCredential] $ServiceNowCredential,
 
         # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]
         $ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Hashtable]
         $Connection,
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [switch] $PassThru
     )
 
-    Invoke-ServiceNowRestMethod @PSBoundParameters -Method 'Post'
+    If ( $PSCmdlet.ShouldProcess($Table, 'Create new entry') ) {
+        $response = Invoke-ServiceNowRestMethod @PSBoundParameters -Method 'Post'
+        If ($PassThru.IsPresent) {
+            $response
+        }
+    }
 }

--- a/ServiceNow/Public/New-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/New-ServiceNowTableEntry.ps1
@@ -2,68 +2,34 @@ function New-ServiceNowTableEntry{
     Param
     (
         # Name of the table we're inserting into (e.g. incidents)
-        [parameter(mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$Table,
-        
-        # Hashtable of values to use as the record's properties
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$Values,
-        
-        # Credential used to authenticate to ServiceNow  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential, 
+        [parameter(Mandatory)]
+        [string] $Table,
 
-        # The URL for the ServiceNow instance being used  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        # Hashtable of values to use as the record's properties
+        [parameter(Mandatory)]
+        [hashtable] $Values,
+
+        # Credential used to authenticate to ServiceNow
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [PSCredential] $ServiceNowCredential,
+
+        # The URL for the ServiceNow instance being used
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $ServiceNowURL, 
+        $ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)] 
+        [Parameter(ParameterSetName='UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Hashtable]
-        $Connection
+        $Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-
-    #Get credential and ServiceNow REST URL
-    if ($Connection -ne $null)
-    {
-        $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-        $ServiceNowCredential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-        $ServiceNowURL = 'https://' + $Connection.ServiceNowUri + '/api/now/v1'
-        
-    } 
-    elseif ($ServiceNowCredential -ne $null -and $ServiceNowURL -ne $null)
-    {
-        $ServiceNowURL = 'https://' + $ServiceNowURL + '/api/now/v1'
-    }
-    elseif((Test-ServiceNowAuthIsSet))
-    {
-        $ServiceNowCredential = $Global:ServiceNowCredentials
-        $ServiceNowURL = $global:ServiceNowRESTURL
-    } 
-    else 
-    {
-        throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-    }
-
-    
-    $Body = $Values | ConvertTo-Json;
-
-    #Convert to UTF8 array to support special chars such as the danish "ï¿½","ï¿½","ï¿½"
-    $utf8Bytes = [System.Text.Encoding]::UTf8.GetBytes($Body)
-
-    # Fire and return
-    $Uri = $ServiceNowURL + "/table/$Table"
-    return (Invoke-RestMethod -Uri $uri -Method Post -Credential $ServiceNowCredential -Body $utf8Bytes -ContentType "application/json" -UseBasicParsing).result
+    Invoke-ServiceNowRestMethod @PSBoundParameters -Method 'Post'
 }

--- a/ServiceNow/Public/Remove-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowAttachment.ps1
@@ -16,7 +16,11 @@ Function Remove-ServiceNowAttachment {
 
     Removes all attachments from CHG0000001
 
-    .NOTES
+    .INPUTS
+    SysId
+
+    .OUTPUTS
+    None
 
     #>
 
@@ -25,25 +29,25 @@ Function Remove-ServiceNowAttachment {
         # Attachment sys_id
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('sys_id')]
-        [string]$SysID,
+        [string] $SysId,
 
         # Credential used to authenticate to ServiceNow
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
-        [PSCredential]$Credential,
+        [PSCredential] $Credential,
 
         # The URL for the ServiceNow instance being used
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateScript( { $_ | Test-ServiceNowURL })]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
-        [string]$ServiceNowURL,
+        [string] $ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection,
+        [Hashtable] $Connection,
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
@@ -53,29 +57,6 @@ Function Remove-ServiceNowAttachment {
     begin {}
 
     process	{
-        # DELETE: https://tenant.service-now.com/api/now/v1/attachment/{sys_id}
-
-        # # Process credential steps based on parameter set name
-        # Switch ($PSCmdlet.ParameterSetName) {
-        #     'SpecifyConnectionFields' {
-        #         $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
-        #         break
-        #     }
-        #     'UseConnectionObject' {
-        #         $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-        #         $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-        #         $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
-        #         break
-        #     }
-        #     Default {
-        #         If (Test-ServiceNowAuthIsSet) {
-        #             $Credential = $Global:ServiceNowCredentials
-        #             $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
-        #         } Else {
-        #             Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-        #         }
-        #     }
-        # }
 
         $params = @{
             Method            = 'Delete'
@@ -89,19 +70,7 @@ Function Remove-ServiceNowAttachment {
         If ($PSCmdlet.ShouldProcess("SysId $SysId", 'Remove attachment')) {
             Invoke-ServiceNowRestMethod @params
         }
-
-        # $Uri = $ApiUrl + '/' + $SysID
-        # Write-Verbose "URI:  $Uri"
-
-        # $invokeRestMethodSplat = @{
-        #     Uri        = $Uri
-        #     Credential = $Credential
-        #     Method     = 'Delete'
-        # }
-
-        # If ($PSCmdlet.ShouldProcess($Uri, $MyInvocation.MyCommand)) {
-        #     (Invoke-RestMethod @invokeRestMethodSplat).Result
-        # }
     }
+
     end {}
 }

--- a/ServiceNow/Public/Remove-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowAttachment.ps1
@@ -20,77 +20,88 @@ Function Remove-ServiceNowAttachment {
 
     #>
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText','')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars','')]
-
-    [CmdletBinding(DefaultParameterSetName,SupportsShouldProcess=$true)]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param(
         # Attachment sys_id
-        [Parameter(
-            Mandatory,
-            ValueFromPipelineByPropertyName = $true
-        )]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('sys_id')]
         [string]$SysID,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
         # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
-        [ValidateScript({$_ | Test-ServiceNowURL})]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateScript( { $_ | Test-ServiceNowURL })]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection
+        [Hashtable]$Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-	begin {}
-	process	{
-		# DELETE: https://tenant.service-now.com/api/now/v1/attachment/{sys_id}
+    begin {}
 
-        # Process credential steps based on parameter set name
-        Switch ($PSCmdlet.ParameterSetName) {
-            'SpecifyConnectionFields' {
-                $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
-                break
-            }
-            'UseConnectionObject' {
-                $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-                $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-                $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
-                break
-            }
-            Default {
-                If (Test-ServiceNowAuthIsSet) {
-                    $Credential = $Global:ServiceNowCredentials
-                    $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
-                }
-                Else {
-                    Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-                }
-            }
+    process	{
+        # DELETE: https://tenant.service-now.com/api/now/v1/attachment/{sys_id}
+
+        # # Process credential steps based on parameter set name
+        # Switch ($PSCmdlet.ParameterSetName) {
+        #     'SpecifyConnectionFields' {
+        #         $ApiUrl = 'https://' + $ServiceNowURL + '/api/now/v1/attachment'
+        #         break
+        #     }
+        #     'UseConnectionObject' {
+        #         $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
+        #         $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
+        #         $ApiUrl = 'https://' + $Connection.ServiceNowUri + '/api/now/v1/attachment'
+        #         break
+        #     }
+        #     Default {
+        #         If (Test-ServiceNowAuthIsSet) {
+        #             $Credential = $Global:ServiceNowCredentials
+        #             $ApiUrl = $Global:ServiceNowRESTURL + '/attachment'
+        #         } Else {
+        #             Throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
+        #         }
+        #     }
+        # }
+
+        $params = @{
+            Method            = 'Delete'
+            UriLeaf           = "/attachment/$SysId"
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
         }
 
-        $Uri = $ApiUrl + '/' + $SysID
-        Write-Verbose "URI:  $Uri"
-
-        $invokeRestMethodSplat = @{
-            Uri         = $Uri
-            Credential  = $Credential
-            Method      = 'Delete'
+        If ($PSCmdlet.ShouldProcess("SysId $SysId", 'Remove attachment')) {
+            Invoke-ServiceNowRestMethod @params
         }
 
-        If ($PSCmdlet.ShouldProcess($Uri,$MyInvocation.MyCommand)) {
-            (Invoke-RestMethod @invokeRestMethodSplat).Result
-        }
+        # $Uri = $ApiUrl + '/' + $SysID
+        # Write-Verbose "URI:  $Uri"
+
+        # $invokeRestMethodSplat = @{
+        #     Uri        = $Uri
+        #     Credential = $Credential
+        #     Method     = 'Delete'
+        # }
+
+        # If ($PSCmdlet.ShouldProcess($Uri, $MyInvocation.MyCommand)) {
+        #     (Invoke-RestMethod @invokeRestMethodSplat).Result
+        # }
     }
-	end {}
+    end {}
 }

--- a/ServiceNow/Public/Remove-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowAttachment.ps1
@@ -27,27 +27,27 @@ Function Remove-ServiceNowAttachment {
     Param(
         # Attachment sys_id
         [Parameter(
-            Mandatory=$true,
+            Mandatory,
             ValueFromPipelineByPropertyName = $true
         )]
         [Alias('sys_id')]
         [string]$SysID,
 
         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
         # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory)]
+        [ValidateScript({$_ | Test-ServiceNowURL})]
         [ValidateNotNullOrEmpty()]
         [Alias('Url')]
         [string]$ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$true)]
+        [Parameter(ParameterSetName='UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Hashtable]$Connection
     )

--- a/ServiceNow/Public/Remove-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowAuth.ps1
@@ -1,18 +1,6 @@
 function Remove-ServiceNowAuth{
 
-    If (-not (Test-ServiceNowAuthIsSet)) {
-        Return $true
-    }
-    
-    Try {
-        Remove-Variable -Name ServiceNowURL -Scope Global -ErrorAction Stop
-        Remove-Variable -Name ServiceNowRESTURL -Scope Global -ErrorAction Stop
-        Remove-Variable -Name ServiceNowCredentials -Scope Global -ErrorAction Stop
-    }
-    Catch {
-        Write-Error $_
-        Return $false
-    }
+    Write-Warning -Message 'Globally scoped variables have been removed from this module, therefore, Remove-ServiceNowAuth is not needed and will be deprecated'
 
     Return $true
 }

--- a/ServiceNow/Public/Remove-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowTableEntry.ps1
@@ -3,7 +3,7 @@ function Remove-ServiceNowTableEntry {
     Param(
         # Table containing the entry we're deleting
         [parameter(Mandatory)]
-        [string]$Table,
+        [string] $Table,
 
         # sys_id of the entry we're deleting
         [parameter(Mandatory)]

--- a/ServiceNow/Public/Remove-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowTableEntry.ps1
@@ -1,62 +1,42 @@
-function Remove-ServiceNowTableEntry{
-[CmdletBinding(ConfirmImpact='High')]
+function Remove-ServiceNowTableEntry {
+    [CmdletBinding(DefaultParameterSetName = 'Session', ConfirmImpact = 'High')]
     Param(
-        # sys_id of the entry we're deleting
-        [parameter(mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$SysId,
-        
         # Table containing the entry we're deleting
-        [parameter(mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
+        [parameter(Mandatory)]
         [string]$Table,
-        
-        # Credential used to authenticate to ServiceNow  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential, 
 
-        # The URL for the ServiceNow instance being used  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        # sys_id of the entry we're deleting
+        [parameter(Mandatory)]
+        [string] $SysId,
+
+        # Credential used to authenticate to ServiceNow
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL, 
+        [PSCredential] $ServiceNowCredential,
+
+        # The URL for the ServiceNow instance being used
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)] 
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [Hashtable] $Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-	#Get credential and ServiceNow REST URL
-    if ($Connection -ne $null)
-    {
-        $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-        $ServiceNowCredential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-        $ServiceNowURL = 'https://' + $Connection.ServiceNowUri + '/api/now/v1'
-        
-    } 
-    elseif ($ServiceNowCredential -ne $null -and $ServiceNowURL -ne $null)
-    {
-        $ServiceNowURL = 'https://' + $ServiceNowURL + '/api/now/v1'
+    $params = @{
+        Method            = 'Delete'
+        Table             = $Table
+        SysId             = $SysId
+        Connection        = $Connection
+        Credential        = $Credential
+        ServiceNowUrl     = $ServiceNowURL
+        ServiceNowSession = $ServiceNowSession
     }
-    elseif((Test-ServiceNowAuthIsSet))
-    {
-        $ServiceNowCredential = $Global:ServiceNowCredentials
-        $ServiceNowURL = $global:ServiceNowRESTURL
-    } 
-    else 
-    {
-        throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-    }
-
-    # Fire and return
-    $Uri = $ServiceNowURL + "/table/$Table/$SysID"
-    return (Invoke-RestMethod -Uri $uri -Method Delete -Credential $ServiceNowCredential -Body $Body -ContentType "application/json").result
+    Invoke-ServiceNowRestMethod @params
 }

--- a/ServiceNow/Public/Set-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuth.ps1
@@ -21,17 +21,15 @@ function Set-ServiceNowAuth {
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
-        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [ValidateScript({$_ | Test-ServiceNowURL})]
         [Alias('ServiceNowUrl')]
-        [string]$Url,
+        [string] $Url,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $Credentials
+        [System.Management.Automation.PSCredential] $Credentials
     )
-    $Global:serviceNowUrl = 'https://' + $Url
-    $Global:serviceNowRestUrl = $serviceNowUrl + '/api/now/v1'
-    $Global:serviceNowCredentials = $Credentials
+    Write-Warning -Message 'Set-ServiceNowAuth will be deprecated in a future release.  Please use New-ServiceNowSession.'
+    New-ServiceNowSession -Url $Url -Credential $Credentials
     return $true
 }

--- a/ServiceNow/Public/Set-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuth.ps1
@@ -20,12 +20,12 @@ function Set-ServiceNowAuth {
 #>
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateScript({$_ | Test-ServiceNowURL})]
         [Alias('ServiceNowUrl')]
         [string] $Url,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential] $Credentials
     )

--- a/ServiceNow/Public/Set-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuth.ps1
@@ -29,7 +29,7 @@ function Set-ServiceNowAuth {
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential] $Credentials
     )
-    Write-Warning -Message 'Set-ServiceNowAuth will be deprecated in a future release.  Please use New-ServiceNowSession.'
-    New-ServiceNowSession -Url $Url -Credential $Credentials
+    Write-Warning -Message 'Set-ServiceNowAuth will be deprecated in a future release.  Please use New-ServiceNowSession.  Also, the current default of v1 of the API will be deprecated in favor of the latest in a future release.  Set-ServiceNowAuth will utilize v1.  To test the latest API, use New-ServiceNowSession.'
+    New-ServiceNowSession -Url $Url -Credential $Credentials -ApiVersion 1
     return $true
 }

--- a/ServiceNow/Public/Test-ServiceNowAuthIsSet.ps1
+++ b/ServiceNow/Public/Test-ServiceNowAuthIsSet.ps1
@@ -1,7 +1,7 @@
 function Test-ServiceNowAuthIsSet{
-    if($Global:ServiceNowCredentials){
+    if($script:ServiceNowSession.Credential){
         return $true;
     }else{
         return $false;
-    }   
+    }
 }

--- a/ServiceNow/Public/Test-ServiceNowAuthIsSet.ps1
+++ b/ServiceNow/Public/Test-ServiceNowAuthIsSet.ps1
@@ -1,7 +1,7 @@
 function Test-ServiceNowAuthIsSet{
-    if($script:ServiceNowSession.Credential){
-        return $true;
+    if ( $ServiceNowSession.Credential -or $ServiceNowSession.AccessToken ){
+        return $true
     }else{
-        return $false;
+        return $false
     }
 }

--- a/ServiceNow/Public/Update-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Update-ServiceNowChangeRequest.ps1
@@ -2,52 +2,61 @@
 .EXAMPLE
     Update-ServiceNowChangeRequest -Values @{ 'state' = 3 } -SysId <sysid>
 #>
-function Update-ServiceNowChangeRequest
-{
+function Update-ServiceNowChangeRequest {
+
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
+
     Param(
         # sys_id of the caller of the incident (use Get-ServiceNowUser to retrieve this)
-        [parameter(Mandatory=$true)]        
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]       
-        [string]$SysId,
+        [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('sys_id')]
+        [string] $SysId,
 
-         # Hashtable of values to use as the record's properties        
-        [parameter(Mandatory=$true)]        
+        # Hashtable of values to use as the record's properties
+        [parameter(Mandatory)]
         [hashtable]$Values,
 
-         # Credential used to authenticate to ServiceNow  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
+        # Credential used to authenticate to ServiceNow
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]$ServiceNowCredential, 
+        [PSCredential]$ServiceNowCredential,
 
         # The URL for the ServiceNow instance being used (eg: instancename.service-now.com)
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$true)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$ServiceNowURL, 
+        [string]$ServiceNowURL,
 
         # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$true)] 
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection
-    )                      
+        [Hashtable]$Connection,
 
-    $updateServiceNowTableEntrySplat = @{
-        SysId = $SysId
-        Table = 'change_request'
-        Values = $Values
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+    )
+
+    begin {
+        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
     }
-    
-    # Update the splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection)
-    {     
-        $updateServiceNowTableEntrySplat.Add('Connection',$Connection)
+
+    process {
+        $params = @{
+            Method            = 'Patch'
+            Table             = 'change_request'
+            SysId             = $SysId
+            Values            = $Values
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        If ($PSCmdlet.ShouldProcess("Change request $SysID", 'Update values')) {
+            Invoke-ServiceNowRestMethod @params
+        }
+
     }
-    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) 
-    {
-         $updateServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
-         $updateServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)
-    }
-       
-    Update-ServiceNowTableEntry @updateServiceNowTableEntrySplat   
+
+    end {}
 }

--- a/ServiceNow/Public/Update-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Update-ServiceNowChangeRequest.ps1
@@ -33,12 +33,13 @@ function Update-ServiceNowChangeRequest {
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [switch] $PassThru
     )
 
-    begin {
-        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
-    }
+    begin {}
 
     process {
         $params = @{
@@ -53,9 +54,11 @@ function Update-ServiceNowChangeRequest {
         }
 
         If ($PSCmdlet.ShouldProcess("Change request $SysID", 'Update values')) {
-            Invoke-ServiceNowRestMethod @params
+            $response = Invoke-ServiceNowRestMethod @params
+            if ( $PassThru.IsPresent ) {
+                $response
+            }
         }
-
     }
 
     end {}

--- a/ServiceNow/Public/Update-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Update-ServiceNowIncident.ps1
@@ -1,49 +1,60 @@
 function Update-ServiceNowIncident {
+
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
+
     Param
     (   # sys_id of the caller of the incident (use Get-ServiceNowUser to retrieve this)
-        [parameter(mandatory=$true)]        
-        [parameter(ParameterSetName='SpecifyConnectionFields', mandatory=$true)]
-        [parameter(ParameterSetName='UseConnectionObject', mandatory=$true)]
-        [parameter(ParameterSetName='SetGlobalAuth', mandatory=$true)]       
-        [string]$SysId,
+        [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('sys_id')]
+        [string] $SysId,
 
-         # Hashtable of values to use as the record's properties        
-        [parameter(mandatory=$true)]        
-        [hashtable]$Values,
+        # Hashtable of values to use as the record's properties
+        [parameter(Mandatory)]
+        [hashtable] $Values,
 
-         # Credential used to authenticate to ServiceNow  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        # Credential used to authenticate to ServiceNow
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]$ServiceNowCredential, 
+        [Alias('ServiceNowCredential')]
+        [PSCredential] $Credential,
 
         # The URL for the ServiceNow instance being used (eg: instancename.service-now.com)
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$ServiceNowURL, 
+        [string] $ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)] 
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection
-    )                      
+        [Hashtable] $Connection,
 
-    $updateServiceNowTableEntrySplat = @{
-        SysId = $SysId
-        Table = 'incident'
-        Values = $Values
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+    )
+
+    begin {
+        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
     }
-    
-    # Update the splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection)
-    {     
-        $updateServiceNowTableEntrySplat.Add('Connection',$Connection)
+
+    process {
+        $params = @{
+            Method            = 'Patch'
+            Table             = 'incident'
+            SysId             = $SysId
+            Values            = $Values
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        If ($PSCmdlet.ShouldProcess("Incident $SysID", 'Update values')) {
+            Invoke-ServiceNowRestMethod @params
+        }
+
     }
-    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) 
-    {
-         $updateServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
-         $updateServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)
-    }
-       
-    Update-ServiceNowTableEntry @updateServiceNowTableEntrySplat
+
+    end {}
 }
 

--- a/ServiceNow/Public/Update-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Update-ServiceNowIncident.ps1
@@ -30,12 +30,13 @@ function Update-ServiceNowIncident {
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [switch] $PassThru
     )
 
-    begin {
-        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
-    }
+    begin {}
 
     process {
         $params = @{
@@ -50,9 +51,11 @@ function Update-ServiceNowIncident {
         }
 
         If ($PSCmdlet.ShouldProcess("Incident $SysID", 'Update values')) {
-            Invoke-ServiceNowRestMethod @params
+            $response = Invoke-ServiceNowRestMethod @params
+            if ( $PassThru.IsPresent ) {
+                $response
+            }
         }
-
     }
 
     end {}

--- a/ServiceNow/Public/Update-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Update-ServiceNowRequestItem.ps1
@@ -20,63 +20,67 @@ function Update-ServiceNowRequestItem {
 
     #>
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText','')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars','')]
+    [OutputType([void], [System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
 
-    [OutputType([void],[System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName,SupportsShouldProcess=$true)]
     Param (
         # sys_id of the ticket to update
-        [Parameter(mandatory=$true)]
-        [string]$SysId,
+        [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('sys_id')]
+        [string] $SysId,
 
-         # Hashtable of values to use as the record's properties
-        [Parameter(mandatory=$true)]
-        [hashtable]$Values,
+        # Hashtable of values to use as the record's properties
+        [Parameter(Mandatory)]
+        [hashtable] $Values,
 
-         # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        # Credential used to authenticate to ServiceNow
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
-        [PSCredential]$Credential,
+        [PSCredential] $Credential,
 
         # The URL for the ServiceNow instance being used (eg: instancename.service-now.com)
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$ServiceNowURL,
+        [string] $ServiceNowURL,
 
         #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection,
+        [Hashtable] $Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
 
         # Switch to allow the results to be passed back
-        [Parameter(Mandatory=$false)]
-        [switch]$PassThru
+        [Parameter()]
+        [switch] $PassThru
     )
 
-    $updateServiceNowTableEntrySplat = @{
-        SysId  = $SysId
-        Table  = 'sc_req_item'
-        Values = $Values
-    }
+    begin {}
 
-    # Update the splat if the parameters have values
-    If ($null -ne $PSBoundParameters.Connection) {
-        $updateServiceNowTableEntrySplat.Add('Connection',$Connection)
-    }
-    ElseIf ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-         $updateServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
-         $updateServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)
-    }
+    process {
 
-    If ($PSCmdlet.ShouldProcess("$Table/$SysID",$MyInvocation.MyCommand)) {
-        # Send REST call
-        $Result = Update-ServiceNowTableEntry @updateServiceNowTableEntrySplat
+        $params = @{
+            Method            = 'Patch'
+            Table             = 'sc_req_item'
+            SysId             = $SysId
+            Values            = $Values
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
 
-        # Option to return results
-        If ($PSBoundParameters.ContainsKey('Passthru')) {
-            $Result
+        If ($PSCmdlet.ShouldProcess("Request Item $SysID", 'Update values')) {
+            $response = Invoke-ServiceNowRestMethod @params
+        }
+
+        if ( $PassThru.IsPresent ) {
+            $response
         }
     }
+
+    end {}
 }

--- a/ServiceNow/Public/Update-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Update-ServiceNowRequestItem.ps1
@@ -53,7 +53,6 @@ function Update-ServiceNowRequestItem {
         [ValidateNotNullOrEmpty()]
         [hashtable] $ServiceNowSession = $script:ServiceNowSession,
 
-        # Switch to allow the results to be passed back
         [Parameter()]
         [switch] $PassThru
     )
@@ -75,11 +74,11 @@ function Update-ServiceNowRequestItem {
 
         If ($PSCmdlet.ShouldProcess("Request Item $SysID", 'Update values')) {
             $response = Invoke-ServiceNowRestMethod @params
+            if ( $PassThru.IsPresent ) {
+                $response
+            }
         }
 
-        if ( $PassThru.IsPresent ) {
-            $response
-        }
     }
 
     end {}

--- a/ServiceNow/Public/Update-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Update-ServiceNowTableEntry.ps1
@@ -32,12 +32,13 @@ function Update-ServiceNowTableEntry {
 
         [Parameter(ParameterSetName = 'Session')]
         [ValidateNotNullOrEmpty()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [switch] $PassThru
     )
 
-    begin {
-        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
-    }
+    begin {}
 
     process {
         $params = @{
@@ -52,7 +53,11 @@ function Update-ServiceNowTableEntry {
         }
 
         If ($PSCmdlet.ShouldProcess("$Table $SysID", 'Update values')) {
-            Invoke-ServiceNowRestMethod @params
+            $response = Invoke-ServiceNowRestMethod @params
+            if ( $PassThru.IsPresent ) {
+                $response
+            }
         }
+
     }
 }

--- a/ServiceNow/Public/Update-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Update-ServiceNowTableEntry.ps1
@@ -35,7 +35,9 @@ function Update-ServiceNowTableEntry {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    begin {}
+    begin {
+        Write-Warning -Message 'PassThru will be implemented in a future release and the response will not be returned by default.  Please update your code to handle this.'
+    }
 
     process {
         $params = @{
@@ -49,6 +51,8 @@ function Update-ServiceNowTableEntry {
             ServiceNowSession = $ServiceNowSession
         }
 
-        Invoke-ServiceNowRestMethod @params
+        If ($PSCmdlet.ShouldProcess("$Table $SysID", 'Update values')) {
+            Invoke-ServiceNowRestMethod @params
+        }
     }
 }

--- a/ServiceNow/Public/Update-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Update-ServiceNowTableEntry.ps1
@@ -1,71 +1,54 @@
-function Update-ServiceNowTableEntry{
-[CmdletBinding(ConfirmImpact='High')]
+function Update-ServiceNowTableEntry {
+    [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
     Param(
-        # sys_id of the entry we're updating
-        [parameter(mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$SysId,
-        
         # Table containing the entry we're updating
-        [parameter(mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$Table,
-        
-        # Credential used to authenticate to ServiceNow  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [PSCredential]$ServiceNowCredential, 
+        [parameter(Mandatory)]
+        [string] $Table,
 
-        # The URL for the ServiceNow instance being used  
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [string]$ServiceNowURL, 
-
-        # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)] 
-        [ValidateNotNullOrEmpty()]
-        [Hashtable]$Connection,
+        # sys_id of the entry we're updating
+        [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('sys_id')]
+        [string] $SysId,
 
         # Hashtable of values to use as the record's properties
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$Values
+        [parameter()]
+        [hashtable] $Values,
+
+        # Credential used to authenticate to ServiceNow
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('ServiceNowCredential')]
+        [PSCredential] $Credential,
+
+        # The URL for the ServiceNow instance being used
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $ServiceNowURL,
+
+        # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [Hashtable] $Connection,
+
+        [Parameter(ParameterSetName = 'Session')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-	# Get credential and ServiceNow REST URL
-    if ($Connection -ne $null)
-    {
-        $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-        $ServiceNowCredential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-        $ServiceNowURL = 'https://' + $Connection.ServiceNowUri + '/api/now/v1'
-        
-    } 
-    elseif ($ServiceNowCredential -ne $null -and $ServiceNowURL -ne $null)
-    {
-        $ServiceNowURL = 'https://' + $ServiceNowURL + '/api/now/v1'
-    }
-    elseif((Test-ServiceNowAuthIsSet))
-    {
-        $ServiceNowCredential = $Global:ServiceNowCredentials
-        $ServiceNowURL = $global:ServiceNowRESTURL
-    } 
-    else
-    {
-        throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
-    }
-  
-    $Body = $Values | ConvertTo-Json
-    
-    # Convert to UTF8 array to support special chars such as the danish "�","�","�"
-    $utf8Bytes = [System.Text.Encoding]::UTf8.GetBytes($Body)
+    begin {}
 
-    # Fire and return
-    $Uri = $ServiceNowURL + "/table/$Table/$SysID"
-    return (Invoke-RestMethod -Uri $uri -Method Patch -Credential $ServiceNowCredential -Body $utf8Bytes -ContentType "application/json").result
+    process {
+        $params = @{
+            Method            = 'Patch'
+            Table             = $Table
+            SysId             = $SysId
+            Values            = $Values
+            Connection        = $Connection
+            Credential        = $Credential
+            ServiceNowUrl     = $ServiceNowURL
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        Invoke-ServiceNowRestMethod @params
+    }
 }

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -59,9 +59,12 @@ FormatsToProcess = @('ServiceNow.format.ps1xml')
 NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Add-ServiceNowAttachment','Get-ServiceNowAttachment','Get-ServiceNowAttachmentDetail','Get-ServiceNowChangeRequest','Get-ServiceNowConfigurationItem','Get-ServiceNowIncident','Get-ServiceNowRequest','Get-ServiceNowRequestItem','Get-ServiceNowTable','Get-ServiceNowTableEntry','Get-ServiceNowUser','Get-ServiceNowUserGroup','New-ServiceNowChangeRequest','New-ServiceNowIncident','New-ServiceNowQuery','New-ServiceNowTableEntry','Remove-ServiceNowAttachment','Remove-ServiceNowAuth','Remove-ServiceNowTableEntry','Set-ServiceNowAuth','Test-ServiceNowAuthIsSet','Update-ServiceNowChangeRequest','Update-ServiceNowIncident','Update-ServiceNowNumber','Update-ServiceNowRequestItem','Update-ServiceNowTableEntry')
+FunctionsToExport = @('New-ServiceNowSession','Add-ServiceNowAttachment','Get-ServiceNowAttachment','Get-ServiceNowAttachmentDetail','Get-ServiceNowChangeRequest','Get-ServiceNowConfigurationItem','Get-ServiceNowIncident','Get-ServiceNowRequest','Get-ServiceNowRequestItem','Get-ServiceNowTable','Get-ServiceNowTableEntry','Get-ServiceNowUser','Get-ServiceNowUserGroup','New-ServiceNowChangeRequest','New-ServiceNowIncident','New-ServiceNowQuery','New-ServiceNowTableEntry','Remove-ServiceNowAttachment','Remove-ServiceNowAuth','Remove-ServiceNowTableEntry','Set-ServiceNowAuth','Test-ServiceNowAuthIsSet','Update-ServiceNowChangeRequest','Update-ServiceNowIncident','Update-ServiceNowNumber','Update-ServiceNowRequestItem','Update-ServiceNowTableEntry')
 
-# List of all modules packaged with this module
+    # Variables to export from this module
+    VariablesToExport = 'ServiceNowSession'
+
+    # List of all modules packaged with this module
 # ModuleList = @()
 
 # List of all files packaged with this module

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.1'
+ModuleVersion = '2.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'

--- a/ServiceNow/ServiceNow.psm1
+++ b/ServiceNow/ServiceNow.psm1
@@ -14,9 +14,12 @@ foreach($Folder in @('Private', 'Public'))
         $Files = Get-ChildItem -Path $Root -Filter *.ps1 -Recurse
 
         # dot source each file
-        $Files | Where-Object{ $_.name -NotLike '*.Tests.ps1'} | 
+        $Files | Where-Object{ $_.name -NotLike '*.Tests.ps1'} |
              ForEach-Object {Write-Verbose $_.basename; . $PSItem.FullName}
     }
 }
 
 Export-ModuleMember -Function (Get-ChildItem -Path "$PSScriptRoot\Public\*.ps1").BaseName
+
+$Script:ServiceNowSession = @{}
+Export-ModuleMember -Variable ServiceNowSession

--- a/Tests/AddServiceNowAttachment.Tests.ps1
+++ b/Tests/AddServiceNowAttachment.Tests.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
     [PSCredential]$Credential
 )

--- a/Tests/GetServiceNowAttachment.Tests.ps1
+++ b/Tests/GetServiceNowAttachment.Tests.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
     [PSCredential]$Credential
 )

--- a/Tests/GetServiceNowAttachmentDetail.Tests.ps1
+++ b/Tests/GetServiceNowAttachmentDetail.Tests.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
     [PSCredential]$Credential
 )

--- a/Tests/RemoveServiceNowAttachment.Tests.ps1
+++ b/Tests/RemoveServiceNowAttachment.Tests.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
     [PSCredential]$Credential
 )

--- a/Tests/ServiceNow.Tests.ps1
+++ b/Tests/ServiceNow.Tests.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [ValidateNotNullorEmpty()]
     [PSCredential]$Credential
 )


### PR DESCRIPTION
- Although still in the module for backward compatibility, `Set-ServiceNowAuth` is being replaced with `New-ServiceNowSession`.  With this comes OAuth support, removal of global variables, and much more folks have asked for.  The ability to provide credentials directly to functions has been retained for this release, but will be deprecated in a future release in favor of using `New-ServiceNowSession`.
- Support for different api versions.  `Set-ServiceNowAuth` will continue to use v1 of the api, but `New-ServiceNowSession` defaults to the latest.  Check out the `-ApiVersion` parameter of `New-ServiceNowSession`.
- `Remove-ServiceNowAuth` has been retained for this release, but as global variables have been removed, there is no longer a need for it; it will always return `$true`.  It will be removed in a future release.
- `-PassThru` added to remaining `Update-` and `New-` functions.  Depending on your code, this may be a ***breaking change*** if you expected the result to be returned.
- Pipeline support added to many functions
- Standardizing on coding between all functions