### PR TITLE
attachment pipeline enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.2
+- Added ability to pipe to `Add-ServiceNowAttachment` and `Get-ServiceNowAttachmentDetail`.  For example, `New-ServiceNowIncident @params -PassThru | Add-ServiceNowAttachment -File MyFile.txt`.  This will create an incident and add an attachment in one step.
+
 ## 2.3.1
 - Fix query operator -notin and -notlike which had a missing space
 - Move verbose logging message in `Invoke-ServiceNowRestMethod` for number of records so it always shows.  This is helpful when you change a filter and can see how many records would be returned without actually returning them.

--- a/ServiceNow/Public/Add-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Add-ServiceNowAttachment.ps1
@@ -17,12 +17,17 @@ Function Add-ServiceNowAttachment {
 
     .EXAMPLE
     Add-ServiceNowAttachment -Number $Number -Table $Table -File .\File01.txt, .\File02.txt
-
+    
     Upload one or more files to a ServiceNow ticket by specifing the number and table
 
     .EXAMPLE
-    Add-ServiceNowAttachment -Number $Number -Table $Table -File .\File01.txt -ContentType 'text/plain'
+    New-ServiceNowIncident @params -PassThru | Add-ServiceNowAttachment -File File01.txt
+    
+    Create a new incident and add an attachment
 
+    .EXAMPLE
+    Add-ServiceNowAttachment -Number $Number -Table $Table -File .\File01.txt -ContentType 'text/plain'
+    
     Upload a file and specify the MIME type (content type).  Should only be required if the function cannot automatically determine the type.
 
     .EXAMPLE
@@ -31,22 +36,20 @@ Function Add-ServiceNowAttachment {
     Upload a file and receive back the file details.
 
     .OUTPUTS
-    System.Management.Automation.PSCustomObject
-
-    .NOTES
-
+    System.Management.Automation.PSCustomObject if -PassThru provided
     #>
 
     [OutputType([PSCustomObject[]])]
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess)]
     Param(
-        # Object number
-        [Parameter(Mandatory)]
-        [string] $Number,
-
         # Table containing the entry
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('sys_class_name')]
         [string]$Table,
+
+        # Object number
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string] $Number,
 
         # Filter results by file name
         [parameter(Mandatory)]
@@ -92,7 +95,7 @@ Function Add-ServiceNowAttachment {
 
         $getSysIdParams = @{
             Table             = $Table
-            Query             = (New-ServiceNowQuery -MatchExact @{'number' = $number })
+            Query             = (New-ServiceNowQuery -Filter @('number', '-eq', $number))
             Properties        = 'sys_id'
             Connection        = $Connection
             Credential        = $Credential

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -20,7 +20,7 @@ CompanyName = 'None'
 Copyright = '(c) 2015-2021 Snow-Shell. All rights reserved.'
 
 # Description of the functionality provided by this module
-Description = 'This module provides cmdlets allowing you to retrieve information from your ServiceNow instance''s REST API'
+Description = 'Automate against ServiceNow service and asset management.  This module can be used standalone or with Azure Automation.'
 
 # Minimum version of the Windows PowerShell engine required by this module
 # PowerShellVersion = '3.0'


### PR DESCRIPTION
- Added ability to pipe to `Add-ServiceNowAttachment` and `Get-ServiceNowAttachmentDetail`.  For example, `New-ServiceNowIncident @params -PassThru | Add-ServiceNowAttachment -File MyFile.txt`.  This will create an incident and add an attachment in one step.