### PR TITLE
Get custom variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.1
+- Add `-IncludeCustomVariable` to `Get-ServiceNowRecord` to retrieve custom variables, eg. ritm form values, in addition to the standard fields.  [#138](https://github.com/Snow-Shell/servicenow-powershell/discussions/138)
+
 ## 2.4
 - Add `New-ServiceNowConfigurationItem`, [#109](https://github.com/Snow-Shell/servicenow-powershell/issues/109)
 - Add grouping operators -and and -group as well as comparison operators -startwith and -endswith to `Get-ServiceNowRecord -Filter` to keep with the -operator standard

--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -52,13 +52,14 @@ function Invoke-ServiceNowRestMethod {
 
         # Fields to return
         [Parameter()]
-        [Alias('Fields')]
-        [string[]] $Properties,
+        [Alias('Fields', 'Properties')]
+        [string[]] $Property,
 
         # Whether or not to show human readable display values instead of machine values
         [Parameter()]
         [ValidateSet('true', 'false', 'all')]
-        [string] $DisplayValues = 'true',
+        [Alias('DisplayValues')]
+        [string] $DisplayValue = 'true',
 
         [Parameter()]
         [PSCredential] $Credential,
@@ -104,7 +105,7 @@ function Invoke-ServiceNowRestMethod {
 
     if ( $Method -eq 'Get') {
         $Body = @{
-            'sysparm_display_value' = $DisplayValues
+            'sysparm_display_value' = $DisplayValue
             'sysparm_query'         = (New-ServiceNowQuery -Filter $Filter -Sort $Sort)
             'sysparm_limit'         = 10
         }
@@ -128,8 +129,8 @@ function Invoke-ServiceNowRestMethod {
             $Body.sysparm_query = $Query
         }
 
-        if ($Properties) {
-            $Body.sysparm_fields = ($Properties -join ',').ToLower()
+        if ($Property) {
+            $Body.sysparm_fields = ($Property -join ',').ToLower()
         }
     }
 

--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -44,7 +44,6 @@ function Invoke-ServiceNowRestMethod {
         [System.Collections.ArrayList] $Filter,
 
         [parameter()]
-        [ValidateNotNullOrEmpty()]
         [System.Collections.ArrayList] $Sort = @('opened_at', 'desc'),
 
         # sysparm_query param in the format of a ServiceNow encoded query string (see http://wiki.servicenow.com/index.php?title=Encoded_Query_Strings)

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -122,15 +122,18 @@ function Get-ServiceNowRecord {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $invokeParams = @{
-        Table             = $Table
-        Properties        = $Property
-        Filter            = $Filter
-        Sort              = $Sort
-        DisplayValues     = $DisplayValue
-        Connection        = $Connection
-        ServiceNowSession = $ServiceNowSession
-    }
+    # $invokeParams = @{
+    #     Table             = $Table
+    #     Properties        = $Property
+    #     Filter            = $Filter
+    #     Sort              = $Sort
+    #     DisplayValues     = $DisplayValue
+    #     Connection        = $Connection
+    #     ServiceNowSession = $ServiceNowSession
+    # }
+
+    $invokeParams = $PSBoundParameters
+    $invokeParams.Remove('IncludeCustomVariable') | Out-Null
 
     $addedSysIdProp = $false
 
@@ -138,7 +141,7 @@ function Get-ServiceNowRecord {
     # add it in if specific properties were requested and not part of the list
     if ( $IncludeCustomVariable.IsPresent ) {
         if ( $Property -and 'sys_id' -notin $Property ) {
-            $invokeParams.Properties += 'sys_id'
+            $invokeParams.Property += 'sys_id'
             $addedSysIdProp = $true
         }
     }

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -36,6 +36,7 @@
     Include custom variables in the return object.
     Some records may have associated custom variables, some may not.
     For instance, an RITM may have custom variables, but the associated tasks may not.
+    A property named 'CustomVariable' will be added to the return object.
 
 .PARAMETER Connection
     Azure Automation Connection object containing username, password, and URL for the ServiceNow instance

--- a/ServiceNow/Public/New-ServiceNowQuery.ps1
+++ b/ServiceNow/Public/New-ServiceNowQuery.ps1
@@ -90,7 +90,6 @@ function New-ServiceNowQuery {
         [System.Collections.ArrayList] $Filter,
 
         [parameter(ParameterSetName = 'Advanced')]
-        [ValidateNotNullOrEmpty()]
         [System.Collections.ArrayList] $Sort
 
     )

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.4'
+ModuleVersion = '2.4.1'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'


### PR DESCRIPTION
- Add `-IncludeCustomVariable` to `Get-ServiceNowRecord` to retrieve custom variables, eg. ritm form values, in addition to the standard fields.  [#138](https://github.com/Snow-Shell/servicenow-powershell/discussions/138)
