### PR TITLE
Fix Bugs with Automatic Table Recognition on Get-ServiceNowRecord

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -229,7 +229,7 @@ function Get-ServiceNowRecord {
             $nameFilter = @($thisTable.DescriptionField, '-like', $Description)
         }
         else {
-            Write-Warning ('We do not have a description field for table ''{0}''; short_description will be used' -f $Table)
+            Write-Warning ('We do not have a description field for table ''{0}''; short_description will be used' -f $thisTable)
             $nameFilter = @('short_description', '-like', $Description)
         }
 
@@ -252,7 +252,7 @@ function Get-ServiceNowRecord {
     }
 
     # should use Get-ServiceNowAttachment, but put this here for ease of access
-    if ( $Table -eq 'attachment' ) {
+    if ( $thisTable -eq 'attachment' ) {
         $invokeParams.Remove('Table') | Out-Null
         $invokeParams.UriLeaf = '/attachment'
     }
@@ -273,7 +273,7 @@ function Get-ServiceNowRecord {
 
                 if ( $customVars ) {
                     $customValueParams = @{
-                        Table    = $Table
+                        Table    = $thisTable
                         Filter   = @('sys_id', '-eq', $record.sys_id)
                         Property = $customVars.'sc_item_option.item_option_new.name' | ForEach-Object { "variables.$_" }
                     }

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -229,7 +229,7 @@ function Get-ServiceNowRecord {
             $nameFilter = @($thisTable.DescriptionField, '-like', $Description)
         }
         else {
-            Write-Warning ('We do not have a description field for table ''{0}''; short_description will be used' -f $thisTable)
+            Write-Warning ('We do not have a description field for table ''{0}''; short_description will be used' -f $thisTable.Name)
             $nameFilter = @('short_description', '-like', $Description)
         }
 
@@ -252,7 +252,7 @@ function Get-ServiceNowRecord {
     }
 
     # should use Get-ServiceNowAttachment, but put this here for ease of access
-    if ( $thisTable -eq 'attachment' ) {
+    if ( $thisTable.Name -eq 'attachment' ) {
         $invokeParams.Remove('Table') | Out-Null
         $invokeParams.UriLeaf = '/attachment'
     }
@@ -273,7 +273,7 @@ function Get-ServiceNowRecord {
 
                 if ( $customVars ) {
                     $customValueParams = @{
-                        Table    = $thisTable
+                        Table    = $thisTable.Name
                         Filter   = @('sys_id', '-eq', $record.sys_id)
                         Property = $customVars.'sc_item_option.item_option_new.name' | ForEach-Object { "variables.$_" }
                     }


### PR DESCRIPTION
Hey there! I discovered a couple issues when you are trying to use the automatic table recognition. Specifically I found that you still had to specify the table when using -IncludeCustomVariable. Looking in the code, it appears there are a couple places where $thisTable should be used instead of $Table. That has been corrected in my PR.

Let me know if you have any questions or corrections or anything!