### PR TITLE
Add datetime support for querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+- Add DateTime support to querying, [#68](https://github.com/Snow-Shell/servicenow-powershell/issues/68)
+
 ## 3.0.2
 - Fix [#152](https://github.com/Snow-Shell/servicenow-powershell/issues/152), object conversion to json failing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.1.0
 - Add DateTime support to querying, [#68](https://github.com/Snow-Shell/servicenow-powershell/issues/68)
+- Add `-between` operator
+- Enhanced value validation for all operators in `New-ServiceNowQuery` which is used by `Get-ServiceNowRecord`
 
 ## 3.0.2
 - Fix [#152](https://github.com/Snow-Shell/servicenow-powershell/issues/152), object conversion to json failing.

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -32,8 +32,6 @@
     Each array should be of the format @(field, comparison operator, value) separated by a join, either 'and', 'or', or 'group'.
     For a complete list of comparison operators, see $script:ServiceNowOperator and use Name in your filter.
     See the examples.
-    Also, see https://docs.servicenow.com/bundle/quebec-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
-    for how to represent date values with javascript.
 
 .PARAMETER Sort
     Array or multidimensional array of fields to sort on.
@@ -86,6 +84,10 @@
     PS > Get-ServiceNowRecord -Table incident -Filter $filter
     Get incident records where state is New and short description contains the word powershell or state is In Progress.
     The first 2 filters are combined and then or'd against the last.
+
+.EXAMPLE
+    Get-ServiceNowRecord -Table 'Incident' -Filter @('opened_at', '-between', (Get-Date).AddMonths(-24), (get-date).AddMonths(-12)) -IncludeTotalCount
+    Get all incident records that were opened between 1 and 2 years ago
 
 .EXAMPLE
     Get-ServiceNowRecord -Table incident -Filter @('state', '-eq', '1') -Sort @('opened_at', 'desc'), @('state')

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.0.2'
+ModuleVersion = '3.1.0'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'

--- a/ServiceNow/config/main.json
+++ b/ServiceNow/config/main.json
@@ -68,109 +68,115 @@
             "Name": "-eq",
             "QueryOperator": "=",
             "Description": "is equal to",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-ne",
             "QueryOperator": "!=",
             "Description": "is not equal to",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "=''",
             "QueryOperator": "ISEMPTY",
             "Description": "field has no value",
-            "RequiresValue": false
+            "NumValues": 0
         },
         {
             "Name": "=\"\"",
             "QueryOperator": "ISEMPTY",
             "Description": "field has no value",
-            "RequiresValue": false
+            "NumValues": 0
         },
         {
             "Name": "!=''",
             "QueryOperator": "ISNOTEMPTY",
             "Description": "field has any value",
-            "RequiresValue": false
+            "NumValues": 0
         },
         {
             "Name": "!=\"\"",
             "QueryOperator": "ISNOTEMPTY",
             "Description": "field has any value",
-            "RequiresValue": false
+            "NumValues": 0
         },
         {
             "Name": "-like",
             "QueryOperator": "LIKE",
             "Description": "value is found anywhere in field",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-notlike",
             "QueryOperator": "NOT LIKE",
             "Description": "value is not found anywhere in field",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-in",
             "QueryOperator": "IN",
             "Description": "field is populated by one of the values",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-notin",
             "QueryOperator": "NOT IN",
             "Description": "field is populated by any value except for these",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-lt",
             "QueryOperator": "<",
             "Description": "field is less than the value.  can be used with dates to represent prior to the value.",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-le",
             "QueryOperator": "<=",
             "Description": "field is less than or equal to the value.  can be used with dates to represent prior to or the day of the value.",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-gt",
             "QueryOperator": ">",
             "Description": "field is greater than the value.  can be used with dates to represent after the value.",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-ge",
             "QueryOperator": ">=",
             "Description": "field is greater than or equal to the value.  can be used with dates to represent after or the day of the value.",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": ".startswith",
             "QueryOperator": "STARTSWITH",
             "Description": "field starts with the value",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-startswith",
             "QueryOperator": "STARTSWITH",
             "Description": "field starts with the value",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": ".endswith",
             "QueryOperator": "%",
             "Description": "field ends with the value",
-            "RequiresValue": true
+            "NumValues": 1
         },
         {
             "Name": "-endswith",
             "QueryOperator": "%",
             "Description": "field ends with the value",
-            "RequiresValue": true
+            "NumValues": 1
+        },
+        {
+            "Name": "-between",
+            "QueryOperator": "BETWEEN",
+            "Description": "value is between 2 dates or integers",
+            "NumValues": 2
         }
     ]
 }


### PR DESCRIPTION
- Add DateTime support to querying, [#68](https://github.com/Snow-Shell/servicenow-powershell/issues/68)
- Add `-between` operator
- Enhanced value validation for all operators in `New-ServiceNowQuery` which is used by `Get-ServiceNowRecord`