### PR TITLE
Fix failure on successful record removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.1
+- Fix [#158](https://github.com/Snow-Shell/servicenow-powershell/issues/68), failure on successful record deletion
+- Move table details retrieval in `New-ServiceNowSession` to be switch operated, `-GetAllTable` and reduce function time
+- Fix pipelining in `Remove-ServiceNowRecord`
+
 ## 3.1.0
 - Add DateTime support to querying, [#68](https://github.com/Snow-Shell/servicenow-powershell/issues/68)
 - Add `-between` operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.1
-- Fix [#158](https://github.com/Snow-Shell/servicenow-powershell/issues/68), failure on successful record deletion
+- Fix [#158](https://github.com/Snow-Shell/servicenow-powershell/issues/158), failure on successful record deletion
 - Move table details retrieval in `New-ServiceNowSession` to be switch operated, `-GetAllTable` and reduce function time
 - Fix pipelining in `Remove-ServiceNowRecord`
 

--- a/ServiceNow/Public/Remove-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Remove-ServiceNowRecord.ps1
@@ -1,13 +1,17 @@
 function Remove-ServiceNowRecord {
+
     [CmdletBinding(ConfirmImpact = 'High')]
+
     Param(
         # Table containing the entry we're deleting
         [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [Alias('sys_class_name')]
         [string] $Table,
 
         # sys_id of the entry we're deleting
         [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [Alias('sys_id')]
         [string] $SysId,
 
@@ -18,13 +22,19 @@ function Remove-ServiceNowRecord {
         [hashtable] $ServiceNowSession = $script:ServiceNowSession
     )
 
-    $params = @{
-        Method            = 'Delete'
-        Table             = $Table
-        SysId             = $SysId
-        Connection        = $Connection
-        ServiceNowSession = $ServiceNowSession
+    begin {
+
     }
-    
-    Invoke-ServiceNowRestMethod @params
+
+    process {
+        $params = @{
+            Method            = 'Delete'
+            Table             = $Table
+            SysId             = $SysId
+            Connection        = $Connection
+            ServiceNowSession = $ServiceNowSession
+        }
+
+        Invoke-ServiceNowRestMethod @params
+    }
 }

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.1.0'
+ModuleVersion = '3.1.1'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'


### PR DESCRIPTION
- Fix [#158](https://github.com/Snow-Shell/servicenow-powershell/issues/158), failure on successful record deletion
- Move table details retrieval in `New-ServiceNowSession` to be switch operated, `-GetAllTable` and reduce function time
- Fix pipelining in `Remove-ServiceNowRecord`
