### PR TITLE
Fix 172 - custom variable values not showing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,3 @@
-- Add `AsValue` parameter to `Get-ServiceNowRecord` to return the underlying value for a property instead of a pscustomobject.  Get your sys_id directly!
-- Add formatting for Unique Certificate (cmdb_ci_certificate) table
+- Fix #172.  Unnecessary 'variable.' prefix has been removed from custom variable property name.
+- Add pipeline functionality to `-Id` parameter of `Get-ServiceNowRecord`
+- Fix `Get-ServiceNowRecord -AsValue` causing error with some values

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
-- Fix #172.  Unnecessary 'variable.' prefix has been removed from custom variable property name.
+- Fix #172, `Get-ServiceNowRecord -IncludeCustomVariable` not returning values
+- `Get-ServiceNowRecord -IncludeCustomVariable` 'variable.' prefix has been removed from custom variable property name.
 - Add pipeline functionality to `-Id` parameter of `Get-ServiceNowRecord`
 - Fix `Get-ServiceNowRecord -AsValue` causing error with some values

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -319,29 +319,30 @@ function Get-ServiceNowRecord {
                 $customVarParams = @{
                     Table             = 'sc_item_option_mtom'
                     Filter            = @('request_item', '-eq', $record.sys_id), 'and', @('sc_item_option.item_option_new.type', '-in', '1,2,3,4,5,6,7,8,9,10,16,18,21,22,26')
-                    Property          = 'sc_item_option.item_option_new.sys_id', 'sc_item_option.value'
+                    Property          = 'sc_item_option.item_option_new.name', 'sc_item_option.value', 'sc_item_option.item_option_new.type', 'sc_item_option.item_option_new.question_text'
                     IncludeTotalCount = $true
                 }
 
-                $customVarsOut = Get-ServiceNowRecord @customVarParams | ForEach-Object {
-                    $itemOptionNewParams = @{
-                        Table    = 'item_option_new'
-                        Id       = $_.'sc_item_option.item_option_new.sys_id'
-                        Property = 'name', 'type', 'question_text'
-                    }
-
-                    $itemOptionNew = Get-ServiceNowRecord @itemOptionNewParams
-
-                    [pscustomobject] @{
-                        'Name'        = $itemOptionNew.name
-                        'Value'       = $_.'sc_item_option.value'
-                        'DisplayName' = $itemOptionNew.question_text
-                        'Type'        = $itemOptionNew.type
-                    }
-                }
+                $customVarsOut = Get-ServiceNowRecord @customVarParams
 
                 $record | Add-Member @{
-                    'CustomVariable' = $customVarsOut
+                    'CustomVariable' = $customVarsOut | Select-Object -Property `
+                    @{
+                        'n' = 'Name'
+                        'e' = { $_.'sc_item_option.item_option_new.name' }
+                    },
+                    @{
+                        'n' = 'Value'
+                        'e' = { $_.'sc_item_option.value' }
+                    },
+                    @{
+                        'n' = 'DisplayName'
+                        'e' = { $_.'sc_item_option.item_option_new.question_text' }
+                    },
+                    @{
+                        'n' = 'Type'
+                        'e' = { $_.'sc_item_option.item_option_new.type' }
+                    }
                 }
 
                 if ( $addedSysIdProp ) {

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.1.7'
+ModuleVersion = '3.1.8'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Fix #172, `Get-ServiceNowRecord -IncludeCustomVariable` not returning values
- `Get-ServiceNowRecord -IncludeCustomVariable` 'variable.' prefix has been removed from custom variable property name.
- Add pipeline functionality to `-Id` parameter of `Get-ServiceNowRecord`
- Fix `Get-ServiceNowRecord -AsValue` causing error with some values