### PR TITLE
Fix 188

### DIFF
--- a/ServiceNow/Public/Add-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Add-ServiceNowAttachment.ps1
@@ -110,7 +110,7 @@ Function Add-ServiceNowAttachment {
     process	{
 
         if ( $Table ) {
-            $thisTableName = $ServiceNowTable.Where{ $_.Name -eq $Table -or $_.ClassName -eq $Table } | Select-Object -ExpandProperty Name
+            $thisTableName = $ServiceNowTable.Where{ $_.ClassName -eq $Table } | Select-Object -ExpandProperty Name
             if ( -not $thisTableName ) {
                 $thisTableName = $Table
             }

--- a/ServiceNow/Public/Export-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Export-ServiceNowRecord.ps1
@@ -87,7 +87,7 @@ function Export-ServiceNowRecord {
                 }
             })]
         [Alias('sys_id', 'number')]
-        [string] $Id,
+        [string] $ID,
 
         [Parameter()]
         [Alias('Fields', 'Properties')]
@@ -123,24 +123,24 @@ function Export-ServiceNowRecord {
             $thisTable = $Table
         }
 
-        if ( $Id ) {
-            if ( $Id -match '^[a-zA-Z0-9]{32}$' ) {
+        if ( $ID ) {
+            if ( $ID -match '^[a-zA-Z0-9]{32}$' ) {
                 if ( -not $thisTable ) {
                     throw 'Providing sys_id for -Id requires a value for -Table.  Alternatively, provide an Id with a prefix, eg. INC1234567, and the table will be automatically determined.'
                 }
 
-                $newFilter = @('sys_id', '-eq', $Id)
+                $newFilter = @('sys_id', '-eq', $ID)
             } else {
                 if ( -not $thisTable ) {
                     # get table name from prefix if only Id was provided
-                    $idPrefix = ($Id | Select-String -Pattern '^([a-zA-Z]+)([0-9]+$)').Matches.Groups[1].Value.ToLower()
+                    $idPrefix = ($ID | Select-String -Pattern '^([a-zA-Z]+)([0-9]+$)').Matches.Groups[1].Value.ToLower()
                     Write-Debug "Id prefix is $idPrefix"
                     $thisTable = $script:ServiceNowTable | Where-Object { $_.NumberPrefix -and $idPrefix -eq $_.NumberPrefix } | Select-Object -ExpandProperty Name
                     if ( -not $thisTable ) {
-                        throw ('The prefix for Id ''{0}'' was not found and the appropriate table cannot be determined.  Known prefixes are {1}.  Please provide a value for -Table.' -f $Id, ($ServiceNowTable.NumberPrefix.Where( { $_ }) -join ', '))
+                        throw ('The prefix for Id ''{0}'' was not found and the appropriate table cannot be determined.  Known prefixes are {1}.  Please provide a value for -Table.' -f $ID, ($ServiceNowTable.NumberPrefix.Where( { $_ }) -join ', '))
                     }
                 }
-                $newFilter = @('number', '-eq', $Id)
+                $newFilter = @('number', '-eq', $ID)
             }
         }
 

--- a/ServiceNow/Public/Get-ServiceNowAttachment.ps1
+++ b/ServiceNow/Public/Get-ServiceNowAttachment.ps1
@@ -112,7 +112,7 @@ Function Get-ServiceNowAttachment {
     process	{
 
         if ( $Table ) {
-            $thisTableName = $ServiceNowTable.Where{ $_.Name -eq $Table -or $_.ClassName -eq $Table } | Select-Object -ExpandProperty Name
+            $thisTableName = $ServiceNowTable.Where{ $_.ClassName -eq $Table } | Select-Object -ExpandProperty Name
             if ( -not $thisTableName ) {
                 $thisTableName = $Table
             }

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -119,7 +119,7 @@
     Get a specific record by number using the function alias
 
 .INPUTS
-    Id
+    ID
 
 .OUTPUTS
     PSCustomObject.  If -AsValue is used, the type will be the selected field.
@@ -152,7 +152,7 @@ function Get-ServiceNowRecord {
                 }
             })]
         [Alias('sys_id', 'number')]
-        [string] $Id,
+        [string] $ID,
 
         [Parameter()]
         [ValidateScript( {
@@ -163,7 +163,7 @@ function Get-ServiceNowRecord {
                     throw 'ParentId must be either a 32 character alphanumeric, ServiceNow sysid, or prefix/id, ServiceNow number.'
                 }
             })]
-        [string] $ParentId,
+        [string] $ParentID,
 
         [Parameter()]
         [string] $Description,
@@ -228,25 +228,25 @@ function Get-ServiceNowRecord {
 
     process {
 
-        if ( $Id ) {
-            if ( $Id -match '^[a-zA-Z0-9]{32}$' ) {
+        if ( $ID ) {
+            if ( $ID -match '^[a-zA-Z0-9]{32}$' ) {
                 if ( -not $thisTable ) {
                     throw 'Providing sys_id for -Id requires a value for -Table.  Alternatively, provide an Id with a prefix, eg. INC1234567, and the table will be automatically determined.'
                 }
 
-                $idFilter = @('sys_id', '-eq', $Id)
+                $idFilter = @('sys_id', '-eq', $ID)
             }
             else {
                 if ( -not $thisTable ) {
                     # get table name from prefix if only Id was provided
-                    $idPrefix = ($Id | Select-String -Pattern '^([a-zA-Z]+)([0-9]+$)').Matches.Groups[1].Value.ToLower()
+                    $idPrefix = ($ID | Select-String -Pattern '^([a-zA-Z]+)([0-9]+$)').Matches.Groups[1].Value.ToLower()
                     Write-Debug "Id prefix is $idPrefix"
                     $thisTable = $script:ServiceNowTable | Where-Object { $_.NumberPrefix -and $idPrefix -eq $_.NumberPrefix }
                     if ( -not $thisTable ) {
-                        throw ('The prefix for Id ''{0}'' was not found and the appropriate table cannot be determined.  Known prefixes are {1}.  Please provide a value for -Table.' -f $Id, ($ServiceNowTable.NumberPrefix.Where( { $_ }) -join ', '))
+                        throw ('The prefix for Id ''{0}'' was not found and the appropriate table cannot be determined.  Known prefixes are {1}.  Please provide a value for -Table.' -f $ID, ($ServiceNowTable.NumberPrefix.Where( { $_ }) -join ', '))
                     }
                 }
-                $idFilter = @('number', '-eq', $Id)
+                $idFilter = @('number', '-eq', $ID)
             }
 
             if ( $invokeParams.Filter ) {
@@ -261,12 +261,12 @@ function Get-ServiceNowRecord {
         # we have the table, update the params
         $invokeParams.Table = $thisTable.Name
 
-        if ( $ParentId ) {
-            if ( $ParentId -match '^[a-zA-Z0-9]{32}$' ) {
-                $parentIdFilter = @('parent.sys_id', '-eq', $ParentId)
+        if ( $ParentID ) {
+            if ( $ParentID -match '^[a-zA-Z0-9]{32}$' ) {
+                $parentIdFilter = @('parent.sys_id', '-eq', $ParentID)
             }
             else {
-                $parentIdFilter = @('parent.number', '-eq', $ParentId)
+                $parentIdFilter = @('parent.number', '-eq', $ParentID)
             }
 
             if ( $invokeParams.Filter ) {

--- a/ServiceNow/Public/Update-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Update-ServiceNowRecord.ps1
@@ -18,13 +18,13 @@
 
 .PARAMETER PassThru
     If provided, the updated record will be returned
-        
+
 .PARAMETER Connection
     Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
 
 .PARAMETER ServiceNowSession
     ServiceNow session created by New-ServiceNowSession.  Will default to script-level variable $ServiceNowSession.
-    
+
 .EXAMPLE
     Update-ServiceNowRecord -Table incident -Id 'INC0010001' -Values @{State = 'Closed'}
     Close an incident record
@@ -47,7 +47,7 @@ function Update-ServiceNowRecord {
 
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('sys_id', 'SysId', 'number')]
-        [string] $Id,
+        [string] $ID,
 
         [parameter(Mandatory)]
         [hashtable] $Values,
@@ -66,15 +66,15 @@ function Update-ServiceNowRecord {
 
     process {
 
-        if ( $Table -and ($Id -match '[a-zA-Z0-9]{32}') ) {
+        if ( $Table -and ($ID -match '[a-zA-Z0-9]{32}') ) {
             # we already have table name and sys_id, no more to do before update
             $tableName = $Table
-            $sysId = $Id
+            $sysId = $ID
         }
         else {
             # get needed details, table name and sys_id, for update
             $getParams = @{
-                Id                = $Id
+                Id                = $ID
                 Property          = 'sys_class_name', 'sys_id', 'number'
                 Connection        = $Connection
                 ServiceNowSession = $ServiceNowSession
@@ -91,7 +91,7 @@ function Update-ServiceNowRecord {
                 $sysId = $thisRecord.sys_id
             }
             else {
-                Write-Error ('Record not found for Id ''{0}''' -f $Id)
+                Write-Error ('Record not found for Id ''{0}''' -f $ID)
                 continue
             }
         }

--- a/ServiceNow/config/main.json
+++ b/ServiceNow/config/main.json
@@ -68,6 +68,13 @@
             "Type": "ServiceNow.UniqueCertificate",
             "NumberPrefix": "",
             "DescriptionField": "name"
+        },
+        {
+            "Name": "kb_knowledge",
+            "ClassName": "Knowledge",
+            "Type": "ServiceNow.Knowledge",
+            "NumberPrefix": "kb",
+            "DescriptionField": "short_description"
         }
     ],
     "FilterOperators": [


### PR DESCRIPTION
- Fix `Get-ServiceNowAttachment` returning 0 records when the table name didn't match the table class name, closes #188 
- Update `Add-ServiceNowAttachment` `-Table` and `-ID` parameters with the same lookup 'smarts' as other functions