### PR TITLE
Allow timeout to be specified for requests

### DIFF
--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -67,7 +67,10 @@ function Invoke-ServiceNowRestMethod {
         [hashtable] $Connection,
 
         [Parameter()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [Int32] $TimeoutSec
     )
 
     # get header/body auth values
@@ -76,6 +79,7 @@ function Invoke-ServiceNowRestMethod {
     $params.Method = $Method
     $params.ContentType = 'application/json'
     $params.UseBasicParsing = $true
+    $params.TimeoutSec = $TimeoutSec
 
     if ( $Table ) {
         # table can either be the actual table name or class name

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -61,6 +61,9 @@
 .PARAMETER ServiceNowSession
     ServiceNow session created by New-ServiceNowSession.  Will default to script-level variable $ServiceNowSession.
 
+.PARAMETER TimeoutSec
+    Specifies how long the request can be pending before it times out. Enter a value in seconds. The default value, 0, specifies an indefinite time-out.
+
 .EXAMPLE
     Get-ServiceNowRecord RITM0010001
 
@@ -224,7 +227,10 @@ function Get-ServiceNowRecord {
         [hashtable] $Connection,
 
         [Parameter()]
-        [hashtable] $ServiceNowSession = $script:ServiceNowSession
+        [hashtable] $ServiceNowSession = $script:ServiceNowSession,
+
+        [Parameter()]
+        [Int32] $TimeoutSec = 0
     )
 
     begin {
@@ -243,6 +249,7 @@ function Get-ServiceNowRecord {
             IncludeTotalCount = $PSCmdlet.PagingParameters.IncludeTotalCount
             Connection        = $Connection
             ServiceNowSession = $ServiceNowSession
+            TimeoutSec        = $TimeoutSec
         }
 
         if ( $PSBoundParameters.ContainsKey('Filter') ) {


### PR DESCRIPTION
This PR is to implement #246 

This is achieved by adding a TimeoutSec parameter to Get-ServiceNowRecord that is passed into Invoke-ServiceNowRestMethod and into the underlying webrequest.

The parameter respects the Powershell Default of 0 for an indefinite timeout, therefore this makes no change in default functionality, and only applies if the parameter is defined.