### PR TITLE
BasicAuth fails when authentication profiles are active on ServiceNow

### DIFF
--- a/ServiceNow/Private/Get-ServiceNowAuth.ps1
+++ b/ServiceNow/Private/Get-ServiceNowAuth.ps1
@@ -35,36 +35,45 @@ function Get-ServiceNowAuth {
                 $hashOut.Headers = @{
                     'Authorization' = 'Bearer {0}' -f $ServiceNowSession.AccessToken.GetNetworkCredential().password
                 }
-            } else {
-                $hashOut.Credential = $ServiceNowSession.Credential
+            }
+            else {
+                # issue 248
+                $pair = '{0}:{1}' -f $ServiceNowSession.Credential.UserName, $ServiceNowSession.Credential.GetNetworkCredential().Password
+                $hashOut.Headers = @{ Authorization = 'Basic ' + [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair)) }
             }
 
             if ( $ServiceNowSession.Proxy ) {
                 $hashOut.Proxy = $ServiceNowSession.Proxy
                 if ( $ServiceNowSession.ProxyCredential ) {
                     $hashOut.ProxyCredential = $ServiceNowSession.ProxyCredential
-                } else {
+                }
+                else {
                     $hashOut.ProxyUseDefaultCredentials = $true
                 }
             }
-        } elseif ( $Connection ) {
+        }
+        elseif ( $Connection ) {
             Write-Verbose 'connection'
-            $SecurePassword = ConvertTo-SecureString $Connection.Password -AsPlainText -Force
-            $Credential = New-Object System.Management.Automation.PSCredential ($Connection.Username, $SecurePassword)
-            $hashOut.Credential = $Credential
+            # issue 248
+            $pair = '{0}:{1}' -f $Connection.Username, $Connection.Password
+            $hashOut.Headers = @{ Authorization = 'Basic ' + [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair)) }
             $hashOut.Uri = 'https://{0}/api/now/v1' -f $Connection.ServiceNowUri
-        } elseif ( $env:SNOW_SERVER ) {
+        }
+        elseif ( $env:SNOW_SERVER ) {
             $hashOut.Uri = 'https://{0}/api/now' -f $env:SNOW_SERVER
             if ( $env:SNOW_TOKEN ) {
                 $hashOut.Headers = @{
                     'Authorization' = 'Bearer {0}' -f $env:SNOW_TOKEN
                 }
-            } elseif ( $env:SNOW_USER -and $env:SNOW_PASS ) {
+            }
+            elseif ( $env:SNOW_USER -and $env:SNOW_PASS ) {
                 $hashOut.Credential = New-Object System.Management.Automation.PSCredential($env:SNOW_USER, ($env:SNOW_PASS | ConvertTo-SecureString -AsPlainText -Force))
-            } else {
+            }
+            else {
                 throw 'A ServiceNow server environment variable has been set, but authentication via SNOW_TOKEN or SNOW_USER/SNOW_PASS was not found'
             }
-        } else {
+        }
+        else {
             throw "You must authenticate by either calling the New-ServiceNowSession cmdlet or passing in an Azure Automation connection object"
         }
     }


### PR DESCRIPTION
Fixes #248 by replacing -Credential with the calculated header.  This should work in the case where authentication profiles are used or not.