### PR TITLE
Fix updates when providing an array

### DIFF
--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -130,7 +130,7 @@ function Invoke-ServiceNowRestMethod {
     }
 
     if ( $Values ) {
-        $Body = $Values | ConvertTo-Json
+        $Body = $Values | ConvertTo-Json -Compress
         $params.Body = $Body
         Write-Verbose ($params | ConvertTo-Json)
 

--- a/ServiceNow/Public/Update-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Update-ServiceNowRecord.ps1
@@ -105,6 +105,13 @@ function Update-ServiceNowRecord {
 
         if ( $PSBoundParameters.ContainsKey('InputData') ) {
 
+            # arrays should be passed as comma-separated
+            foreach ($key in @($InputData.Keys)) {
+                if ( $InputData[$key].GetType().IsArray ) {
+                    $InputData[$key] = $InputData[$key] -join ','
+                }
+            }
+
             $params = @{
                 Method            = 'Patch'
                 Table             = $thisTable.Name


### PR DESCRIPTION
- List type fields cannot be updated with an array as SN adds brackets from the JSON.  Change arrays to comma separated strings in `Update-ServiceNowRecord` as SN requires.  Fix #260 