### PR TITLE
Add ExpiresOn property to ServiceNow session

### DIFF
--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -197,6 +197,11 @@ function New-ServiceNowSession {
                 $token = $response.Content | ConvertFrom-Json
                 $newSession.Add('AccessToken', (New-Object System.Management.Automation.PSCredential('AccessToken', ($token.access_token | ConvertTo-SecureString -AsPlainText -Force))))
                 $newSession.Add('RefreshToken', (New-Object System.Management.Automation.PSCredential('RefreshToken', ($token.refresh_token | ConvertTo-SecureString -AsPlainText -Force))))
+                if ($token.expires_in) {
+                    $expiryTime = (Get-Date).AddSeconds($token.expires_in)
+                    $newSession.Add('ExpiresOn', $expiryTime)
+                    Write-Verbose "Token will expire at $expiryTime"
+                }
             }
             else {
                 # invoke-webrequest didn't throw an error, but we didn't get a token back either


### PR DESCRIPTION
While this change doesn't handle re-authentication automatically, it makes session management significantly easier in code by providing clear token expiration visibility and a consistent way to check if a new session is needed.