### PR TITLE
Stop forcing field names to lowercase

### DIFF
--- a/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
+++ b/ServiceNow/Private/Invoke-ServiceNowRestMethod.ps1
@@ -127,7 +127,7 @@ function Invoke-ServiceNowRestMethod {
         }
 
         if ($Property) {
-            $Body.sysparm_fields = ($Property -join ',').ToLower()
+            $Body.sysparm_fields = $Property -join ','
         }
 
         if ( $Body ) {

--- a/ServiceNow/Public/Export-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Export-ServiceNowRecord.ps1
@@ -17,7 +17,8 @@
     If providing just an Id, not with Table, the Id prefix will be looked up to find the table name.
 
 .PARAMETER Property
-    Return one or more specific fields otherwise all fields will be returned
+    Return one or more specific fields otherwise all fields will be returned.
+    Field names are case sensitive.
 
 .PARAMETER Filter
     Array or multidimensional array of fields and values to filter on.

--- a/ServiceNow/Public/Get-ServiceNowRecord.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRecord.ps1
@@ -25,7 +25,8 @@
     The comparison performed is a 'like'.
 
 .PARAMETER Property
-    Return one or more specific fields otherwise all fields will be returned
+    Return one or more specific fields otherwise all fields will be returned.
+    Field names are case sensitive.
 
 .PARAMETER Filter
     Array or multidimensional array of fields and values to filter on.


### PR DESCRIPTION
As mentioned in #281, sysparm_fields has been forced to lowercase for as long as this module has been around.  As it turns out, field names are case sensitive so remove this and send the field names as is.