### PR TITLE
Add support for authenticating with OAuth Client Credential Grant

### DIFF
--- a/ServiceNow/Private/Get-ServiceNowAuth.ps1
+++ b/ServiceNow/Private/Get-ServiceNowAuth.ps1
@@ -38,31 +38,52 @@ function Get-ServiceNowAuth {
             if ($ServiceNowSession.Version) { $hashOut.uri = $hashOut.uri + $ServiceNowSession.Version }
 
             # check if we need a new access token
-            if ( $ServiceNowSession.ExpiresOn -lt (Get-Date) -and $ServiceNowSession.RefreshToken -and $ServiceNowSession.ClientCredential ) {
-                # we've expired and have a refresh token
-                $refreshParams = @{
-                    Uri         = 'https://{0}/oauth_token.do' -f $ServiceNowSession.Domain
-                    Method      = 'POST'
-                    ContentType = 'application/x-www-form-urlencoded'
-                    Body        = @{
-                        grant_type    = 'refresh_token'
-                        client_id     = $ServiceNowSession.ClientCredential.UserName
-                        client_secret = $ServiceNowSession.ClientCredential.GetNetworkCredential().password
-                        refresh_token = $ServiceNowSession.RefreshToken.GetNetworkCredential().password
+            if ( $ServiceNowSession.ExpiresOn -lt (Get-Date) -and $ServiceNowSession.ClientCredential ) {
+                
+                # Build refresh/re-auth body based on grant type
+                $refreshBody = @{
+                    client_id     = $ServiceNowSession.ClientCredential.UserName
+                    client_secret = $ServiceNowSession.ClientCredential.GetNetworkCredential().password
+                }
+
+                if ($ServiceNowSession.GrantType -eq 'client_credentials') {
+                    # Client credentials: re-authenticate (no refresh token available)
+                    $refreshBody['grant_type'] = 'client_credentials'
+                }
+                elseif ($ServiceNowSession.RefreshToken) {
+                    # Password grant: use refresh token
+                    $refreshBody['grant_type'] = 'refresh_token'
+                    $refreshBody['refresh_token'] = $ServiceNowSession.RefreshToken.GetNetworkCredential().password
+                }
+                else {
+                    Write-Warning 'Access token expired but no refresh method available'
+                }
+
+                if ($refreshBody.ContainsKey('grant_type')) {
+                    $refreshParams = @{
+                        Uri         = 'https://{0}/oauth_token.do' -f $ServiceNowSession.Domain
+                        Method      = 'POST'
+                        ContentType = 'application/x-www-form-urlencoded'
+                        Body        = $refreshBody
                     }
+
+                    $response = Invoke-RestMethod @refreshParams
+
+                    $ServiceNowSession.AccessToken = New-Object System.Management.Automation.PSCredential('AccessToken', ($response.access_token | ConvertTo-SecureString -AsPlainText -Force))
+                    
+                    # Update refresh token if provided (password grant only)
+                    if ($response.refresh_token) {
+                         $ServiceNowSession.RefreshToken = New-Object System.Management.Automation.PSCredential('RefreshToken', ($response.refresh_token | ConvertTo-SecureString -AsPlainText -Force))
+                    }
+
+                    if ($response.expires_in) {
+                        $ServiceNowSession.ExpiresOn = (Get-Date).AddSeconds($response.expires_in)
+                        Write-Verbose ('Access token has been refreshed and will expire at {0}' -f $ServiceNowSession.ExpiresOn)
+                    }
+
+                    # ensure script/module scoped variable is updated
+                    $script:ServiceNowSession = $ServiceNowSession
                 }
-
-                $response = Invoke-RestMethod @refreshParams
-
-                $ServiceNowSession.AccessToken = New-Object System.Management.Automation.PSCredential('AccessToken', ($response.access_token | ConvertTo-SecureString -AsPlainText -Force))
-                $ServiceNowSession.RefreshToken = New-Object System.Management.Automation.PSCredential('RefreshToken', ($response.refresh_token | ConvertTo-SecureString -AsPlainText -Force))
-                if ($response.expires_in) {
-                    $ServiceNowSession.ExpiresOn = (Get-Date).AddSeconds($response.expires_in)
-                    Write-Verbose ('Access token has been refreshed and will expire at {0}' -f $ServiceNowSession.ExpiresOn)
-                }
-
-                # ensure script/module scoped variable is updated
-                $script:ServiceNowSession = $ServiceNowSession
             }
 
             if ( $ServiceNowSession.AccessToken ) {

--- a/ServiceNow/Public/New-ServiceNowSession.ps1
+++ b/ServiceNow/Public/New-ServiceNowSession.ps1
@@ -101,6 +101,7 @@ function New-ServiceNowSession {
 
         [Parameter(Mandatory, ParameterSetName = 'OAuth')]
         [Parameter(Mandatory, ParameterSetName = 'OAuthProxy')]
+        [Parameter(Mandatory, ParameterSetName = 'OAuthClientCredential')]
         [System.Management.Automation.PSCredential] $ClientCredential,
 
         [Parameter(Mandatory, ParameterSetName = 'AccessToken')]
@@ -160,19 +161,32 @@ function New-ServiceNowSession {
     }
 
     $script:PSDefaultParameterValues['Invoke-WebRequest:TimeoutSec'] = $TimeoutSec
-    $script:PSDefaultParameterValues['Invoke-RestMethodt:TimeoutSec'] = $TimeoutSec
+    $script:PSDefaultParameterValues['Invoke-RestMethod:TimeoutSec'] = $TimeoutSec
 
     switch -Wildcard ($PSCmdLet.ParameterSetName) {
         'OAuth*' {
+            # Determine OAuth grant type and build request body
+            $oauthBody = @{
+                'client_id'     = $ClientCredential.UserName
+                'client_secret' = $ClientCredential.GetNetworkCredential().Password
+            }
+
+            if ($PSCmdLet.ParameterSetName -eq 'OAuthClientCredential') {
+                # Client Credentials Grant (machine-to-machine)
+                $oauthBody['grant_type'] = 'client_credentials'
+                $grantType = 'client_credentials'
+            }
+            else {
+                # Password Grant (user credentials)
+                $oauthBody['grant_type'] = 'password'
+                $oauthBody['username'] = $Credential.UserName
+                $oauthBody['password'] = $Credential.GetNetworkCredential().Password
+                $grantType = 'password'
+            }
+
             $params = @{
                 Uri             = 'https://{0}/oauth_token.do' -f $Url
-                Body            = @{
-                    'grant_type'    = 'password'
-                    'client_id'     = $ClientCredential.UserName
-                    'client_secret' = $ClientCredential.GetNetworkCredential().Password
-                    'username'      = $Credential.UserName
-                    'password'      = $Credential.GetNetworkCredential().Password
-                }
+                Body            = $oauthBody
                 Method          = 'Post'
                 UseBasicParsing = $true
             }
@@ -198,18 +212,24 @@ function New-ServiceNowSession {
             if ( $response.Content ) {
                 $token = $response.Content | ConvertFrom-Json
                 $newSession.Add('AccessToken', (New-Object System.Management.Automation.PSCredential('AccessToken', ($token.access_token | ConvertTo-SecureString -AsPlainText -Force))))
-                $newSession.Add('RefreshToken', (New-Object System.Management.Automation.PSCredential('RefreshToken', ($token.refresh_token | ConvertTo-SecureString -AsPlainText -Force))))
+                
+                # Password grant returns refresh_token, client credentials does not
+                if ($token.refresh_token) {
+                    $newSession.Add('RefreshToken', (New-Object System.Management.Automation.PSCredential('RefreshToken', ($token.refresh_token | ConvertTo-SecureString -AsPlainText -Force))))
+                }
+
                 if ($token.expires_in) {
                     $expiryTime = (Get-Date).AddSeconds($token.expires_in)
                     $newSession.Add('ExpiresOn', $expiryTime)
                     Write-Verbose "Access token will expire at $expiryTime"
                 }
-                # store client credential as it will be needed to refresh the access token
-                $newSession.Add('ClientCredential', $ClientCredential)
 
+                # Store credentials and grant type for token refresh
+                $newSession.Add('ClientCredential', $ClientCredential)
+                $newSession.Add('GrantType', $grantType)
             } else {
                 # invoke-webrequest didn't throw an error, but we didn't get a token back either
-                throw ('"{0} : {1}' -f $response.StatusCode, $response | Out-String )
+                throw ('{0} : {1}' -f $response.StatusCode, $response | Out-String )
             }
         }
 


### PR DESCRIPTION
These changes were developed to support OAuth flows required by our internal production use of this module, and we’re sharing them here in case they’re useful to the broader community. Maintainers are welcome to adapt or refine it further as they see fit.

---

This pull request enhances the ServiceNow PowerShell module's OAuth authentication flow, adding support for both the "password" and "client_credentials" OAuth grant types.

**OAuth Grant Type Support and Session Handling:**

* Added explicit support for the `OAuthClientCredential` parameter set in `New-ServiceNowSession`, allowing users to authenticate using the "client_credentials" grant type for machine-to-machine scenarios.
* The session object now records the grant type (`GrantType`) and always stores the client credential, ensuring the correct refresh or re-authentication flow can be determined later.

**Token Request and Refresh Logic:**

* Updated `New-ServiceNowSession` to dynamically build the OAuth token request body based on the grant type, supporting both "password" (user credentials) and "client_credentials" (no user context) flows.
* Improved token refresh logic in `Get-ServiceNowAuth` to distinguish between grant types: it re-authenticates using client credentials if no refresh token is available, or uses the refresh token if present (password grant). It also handles the absence of a refresh method gracefully.
* Ensured the refresh token is only updated or stored when provided by the ServiceNow response, which only occurs in the password grant flow. 
* 
**Bug Fixes and Minor Improvements:**

* Fixed a typo in the default parameter value for `Invoke-RestMethod:TimeoutSec`, ensuring correct timeout handling for REST calls.
* Improved error messaging for failed token retrieval scenarios.