### PR TITLE
Change QueryOperator to 'ENDSWITH' for -endswith

### DIFF
--- a/ServiceNow/config/main.json
+++ b/ServiceNow/config/main.json
@@ -189,7 +189,7 @@
         },
         {
             "Name": "-endswith",
-            "QueryOperator": "%",
+            "QueryOperator": "ENDSWITH",
             "Description": "field ends with the value",
             "NumValues": 1
         },


### PR DESCRIPTION
This solves the issue where by using -endswith returns all entries and not those that end with the value passed in.

It also aligns -endswith and -startswith so they both work consistently